### PR TITLE
Ch7070 fix blocking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,6 +32,7 @@ podTemplate(label: 'plaid-rpc',
       stage("Run Checks") {
         if (!params.skip_lint) {
           sh """
+            pip install -e .
             lint --target-dir=$params.target_lint_dir --branch=$branch --full-lint=$params.full_lint
             pytest
           """

--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -38,31 +38,6 @@ if not os.path.exists(download_folder):
     os.makedirs(download_folder)
 
 
-def get(token, uri=None, verify_ssl=None, proxy_url=None, proxy_user=None, proxy_password=None):
-    """Convenience Wrapper for JSON-RPC Connection"""
-
-    warnings.simplefilter('always', DeprecationWarning)
-    warnings.warn(
-        'plaidtools.connection.jsonrpc.get uses a deprecated Websocket connection. Consider using \
-                a plaidtools.connection.jsonrpc.SimpleRPC object instead',
-        DeprecationWarning
-    )
-
-    from plaidtools.remote.jsonrpc import JsonRpc
-    from plaidtools.remote.auth import oauth2_auth
-
-    auth_object = oauth2_auth(token)
-
-    return JsonRpc(
-        auth=auth_object,
-        uri=uri,
-        verify_ssl=verify_ssl,
-        proxy_url=proxy_url,
-        proxy_user=proxy_user,
-        proxy_password=proxy_password,
-    )
-
-
 def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, workspace=None, proxies=None,
                   fire_and_forget=False, check_allow_transmit=None):
     """

--- a/plaidcloud/rpc/remote/json_rpc_handler.py
+++ b/plaidcloud/rpc/remote/json_rpc_handler.py
@@ -24,12 +24,14 @@ class JsonRpcHandler(tornado.web.RequestHandler):
     """
 
     def initialize(self, *args, **kwargs):
+        super(JsonRpcHandler, self).initialize()
         self.validations = []
         self.logger = logging.getLogger(__name__)
         self.base_path = None
         self.extra_params = {}
 
     async def prepare(self):
+        # await super(JsonRpcHandler, self).prepare()  # Not required if validating by oAuth in plaid
         try:
             await self.validate()
         except Exception as e:

--- a/plaidcloud/rpc/remote/json_rpc_server.py
+++ b/plaidcloud/rpc/remote/json_rpc_server.py
@@ -4,10 +4,12 @@
 from __future__ import print_function
 
 from __future__ import absolute_import
+import asyncio
 import json
 import logging
 
 from toolz.dicttoolz import merge
+from functools import partial
 
 from plaidcloud.rpc.remote.rpc_common import call_as_coroutine
 
@@ -277,7 +279,9 @@ async def process_rpc(rpc_args, auth_id, version=1, base_path=BASE_MODULE_PATH, 
                         }
                     try:
                         logger.info('Start "{}" {}'.format(method, id))
-                        (result, error) = await call_as_coroutine(callable_object, default_error, **merge(params, extra_params))
+                        result, error = await asyncio.get_event_loop().run_in_executor(
+                            None, partial(call_as_coroutine, callable_object, default_error, **merge(params, extra_params))
+                        )
                         logger.info('Complete "{}" {}'.format(method, id))
 
                     except TypeError:

--- a/plaidcloud/rpc/remote/rpc_common.py
+++ b/plaidcloud/rpc/remote/rpc_common.py
@@ -13,7 +13,6 @@ from operator import itemgetter
 from functools import wraps as _wraps
 from six import string_types
 
-import functools
 from toolz.itertoolz import groupby, concat
 from toolz.functoolz import identity
 
@@ -182,10 +181,10 @@ def rpc_method(required_scope=None, default_error=None, kwarg_transformation=ide
     return real_decorator
 
 
-async def call_as_coroutine(function, default_error, **kwargs):
+def call_as_coroutine(function, default_error, **kwargs):
     try:
         if asyncio.iscoroutinefunction(function):
-            result = await function(**kwargs)
+            result = asyncio.get_event_loop().run_until_complete(function(**kwargs))
         else:
             # If it's not a coroutine, we need to make it one with run_in_executor
             def function_with_error_print(**kwargs):
@@ -214,9 +213,7 @@ async def call_as_coroutine(function, default_error, **kwargs):
                 else:
                     return rval
 
-            result = await asyncio.get_event_loop().run_in_executor(
-                None, functools.partial(function_with_error_print, **kwargs)
-            )
+            result = function_with_error_print(**kwargs)
         return result, None
     except RPCError as e:
         return None, e.json_error()


### PR DESCRIPTION
This attempts to address some of the blocking that is happening after switch to asyncio. Using  `run_in_executor()` and `asyncio .run_until_complete()` to run each RPC in a separate thread.