### PR TITLE
Ch7047 - Raise 401 if validations fail

### DIFF
--- a/plaidcloud/rpc/remote/json_rpc_handler.py
+++ b/plaidcloud/rpc/remote/json_rpc_handler.py
@@ -53,10 +53,13 @@ class JsonRpcHandler(tornado.web.RequestHandler):
                     self.scopes.add('public')
                 break
         else:
-            self.logger.warning('No validation methods worked, defaulting to "public" scope only!')
-            self.workspace_id = None
-            self.scopes = {'public'}
-            self.user_id = None
+            # self.logger.warning('No validation methods worked, defaulting to "public" scope only!')
+            # self.workspace_id = None
+            # self.scopes = {'public'}
+            # self.user_id = None
+            self.set_header('Content-Type', 'application/json')
+            self.set_status(401)
+            self.finish()
 
     async def _validate_pass(self):
         # Just pass through with no validation.

--- a/plaidcloud/rpc/remote/rpc_common.py
+++ b/plaidcloud/rpc/remote/rpc_common.py
@@ -185,7 +185,16 @@ def rpc_method(required_scope=None, default_error=None, kwarg_transformation=ide
 def call_as_coroutine(function, default_error, **kwargs):
     try:
         if asyncio.iscoroutinefunction(function):
-            result = asyncio.get_event_loop().run_until_complete(function(**kwargs))
+            try:
+                result = asyncio.get_event_loop().run_until_complete(function(**kwargs))
+            except Warning:
+                raise
+            except RPCError:
+                traceback.print_exc(file=sys.stderr)
+                raise
+            except:
+                traceback.print_exc(file=sys.stderr)
+                raise RPCError(message=traceback.format_exc(), code=-32603)
         else:
             # If it's not a coroutine, we need to make it one with run_in_executor
             def function_with_error_print(**kwargs):


### PR DESCRIPTION
If validations failed, the RPC still returned a default scope of public. This wasn't correct if the user session had timed out so return a 401 such that the user get's a redirect to login.

Also fixes issue where errors were not passed down the chain as before with RPC errors