### PR TITLE
Fix kwarg deprecation in urllib3

### DIFF
--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -132,7 +132,7 @@ class RPCRetry(Retry):
                 This can be used to prevent retry of RPC methods once a workflow has been cancelled and the RPC fails
         """
         kwargs.update(dict(
-            method_whitelist=['POST'],
+            allowed_methods=['POST'],
             status_forcelist=[500, 502, 504],
             backoff_factor=0.1,
         ))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ sqlalchemy-hana
 toolz
 tornado
 unicodecsv
-urllib3
+urllib3>=1.26.0
 xlrd


### PR DESCRIPTION
`method_whitelist` has been dropped in favour of `allowed_methods`