### PR TITLE
Streamable endpoint to take an async stream callback method

### DIFF
--- a/plaidcloud/rpc/remote/rpc_common.py
+++ b/plaidcloud/rpc/remote/rpc_common.py
@@ -135,7 +135,7 @@ async def cosubcall(rpc_future):
         raise RPCError(**err)
 
 
-def rpc_method(required_scope=None, default_error=None, kwarg_transformation=identity):
+def rpc_method(required_scope=None, default_error=None, is_streamed=False, kwarg_transformation=identity):
     """Decorator for packaging up Exceptions as json_rpc errors.
 
     Args:
@@ -178,6 +178,7 @@ def rpc_method(required_scope=None, default_error=None, kwarg_transformation=ide
         wrapper.rpc_method = True  # Set a flag that we can check for in the json_rpc handler
         wrapper.required_scope = required_scope
         wrapper.default_error = default_error
+        wrapper.is_streamed = is_streamed
         return wrapper
 
     return real_decorator
@@ -203,7 +204,7 @@ async def call_as_coroutine(function, default_error, **kwargs):
                 # mitigate it a little here.
                 try:
                     if getattr(asyncio, 'to_thread', None):
-                        rval = await asyncio.to_thread(function(**kw))
+                        rval = await asyncio.to_thread(function, **kw)
                     else:
                         rval = await asyncio.get_event_loop().run_in_executor(
                             None, partial(function, **kw)

--- a/plaidcloud/rpc/remote/rpc_tools.py
+++ b/plaidcloud/rpc/remote/rpc_tools.py
@@ -35,7 +35,7 @@ def get_auth_id(workspace_id, member_id, scopes):
 
 
 def direct_rpc(auth_id, method, params):
-    callable_object, required_scope, default_error = get_callable_object(method, version=1, base_path=BASE_MODULE_PATH, logger=None)
+    callable_object, required_scope, default_error, is_streamed = get_callable_object(method, version=1, base_path=BASE_MODULE_PATH, logger=None)
     if asyncio.iscoroutinefunction(callable_object):
         result = asyncio.get_event_loop().run_until_complete(callable_object(auth_id=auth_id, **params))
     else:
@@ -52,7 +52,7 @@ def direct_rpc(auth_id, method, params):
 
 
 async def direct_rpc_async(auth_id, method, params):
-    callable_object, required_scope, default_error = get_callable_object(method, version=1, base_path=BASE_MODULE_PATH, logger=None)
+    callable_object, required_scope, default_error, is_streamed = get_callable_object(method, version=1, base_path=BASE_MODULE_PATH, logger=None)
     if asyncio.iscoroutinefunction(callable_object):
         result = await callable_object(auth_id=auth_id, **params)
     else:


### PR DESCRIPTION
An rpc method can be declared with `is_streamed=True` in the decorator, and by adding a `stream_callback` parameter to the method, it allows the streaming to be performed non-blocking under asyncio.