### PR TITLE
Streamed Json RPC Fixes

### DIFF
--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -99,6 +99,7 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, workspa
                                   allow_redirects=False, stream=True) as data:
                     for chunk in data.iter_content(chunk_size=None):
                         tmp_file.write(chunk)
+                    data.raise_for_status()
             return file_name
         elif fire_and_forget:
             r_future = session.post(uri, headers=headers, data=payload, verify=verify_ssl, proxies=proxies,

--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -83,7 +83,10 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, workspa
         return requests.sessions.Session()
 
     with get_session() as session:
-        retry = RPCRetry(check_allow_transmit=check_allow_transmit)
+        if streamable():
+            retry = 0
+        else:
+            retry = RPCRetry(check_allow_transmit=check_allow_transmit)
         adapter = HTTPAdapter(max_retries=retry)
         session.mount('http://', adapter)
         session.mount('https://', adapter)

--- a/plaidcloud/rpc/remote/json_rpc_handler.py
+++ b/plaidcloud/rpc/remote/json_rpc_handler.py
@@ -100,8 +100,9 @@ class JsonRpcHandler(tornado.web.RequestHandler):
             result = await execute_json_rpc(msg, auth_id, base_path=self.base_path, logger=self.logger, extra_params=self.extra_params, stream_callback=stream_callback)
 
         self.logger.debug('RPC call complete - building response')
-        if self.streamed:
-            pass
+        if self.streamed or 'download_csv' in msg:
+            if not result['ok']:
+                self.send_error()
         elif isinstance(result.get('result'), types.GeneratorType):
             # RPC endpoint returned a generator, so we'll use chunked
             # transfer encoding to stream it (via tornado yield magic).


### PR DESCRIPTION
Send an error server-side if the RPC failed whilst streaming.
Raise an error if the response calls for it.
Don't retry a streamed endpoint, I'm not sure how it deals with the data writing to file in that case.
