### PR TITLE
Ch7827

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'sqlalchemy',
         'sqlalchemy-greenplum',
         'sqlalchemy-hana',
-        'toolz==0.10.0',
+        'toolz',
         'tornado',
         'unicodecsv',
         'urllib3',


### PR DESCRIPTION
Removes version pin from the one library that had it (it looks like the reason for that pin was the use of dicttoolz.iteritems)