### PR TITLE
sc-7911 Only include a Traceback in the response if the system_user is True

### DIFF
--- a/plaidcloud/rpc/remote/json_rpc_server.py
+++ b/plaidcloud/rpc/remote/json_rpc_server.py
@@ -278,7 +278,9 @@ async def execute_json_rpc(msg, auth_id, version=1, base_path=BASE_MODULE_PATH, 
         params['stream_callback'] = stream_callback
     all_params = merge(params, extra_params or {})
     try:
-        result, error = await call_as_coroutine(callable_object, default_error, use_thread, is_streamed, **all_params)
+        result, error = await call_as_coroutine(
+            callable_object, default_error, use_thread, is_streamed, auth_id.get('system_user', False), logger, **all_params
+        )
     except TypeError:
         logger.exception("Type Error")
         # Check the callable object and make sure all the required args are present


### PR DESCRIPTION
Plaid will be setting the system_user flag for Project Users in a corresponding PR. This allows Tracebacks to filter through to Workflow Runner, but not get sent out to the UI or any other user RPC call.