### PR TITLE
Do not leak Traceback to RPC clients

### DIFF
--- a/plaidcloud/rpc/remote/rpc_common.py
+++ b/plaidcloud/rpc/remote/rpc_common.py
@@ -192,10 +192,11 @@ def rpc_method(required_scope=None, default_error=None, is_streamed=False, use_t
 
 async def call_as_coroutine(function, default_error, use_thread, is_streamed, system_user, logger, **kwargs):
     def _get_error_message(exc):
-        if system_user:
-            return traceback.format_exc()
-        else:
-            return f'{"Unexpected error" if not default_error else default_error} - {str(exc)}'
+        # if system_user:
+        #     return traceback.format_exc()
+        # else:
+        #     return f'{"Unexpected error" if not default_error else default_error} - {str(exc)}'
+        return f'{"Unexpected error" if not default_error else default_error}'
     try:
         if asyncio.iscoroutinefunction(function):
             try:


### PR DESCRIPTION
Don't leak a full Traceback to the RPC clients, it could contain sensitive information.