### PR TITLE
Move Starrocks and HANA to testing dependencies

### DIFF
--- a/plaidcloud/rpc/database.py
+++ b/plaidcloud/rpc/database.py
@@ -24,10 +24,22 @@ from sqlalchemy.dialects.mssql.base import MSDialect, UNIQUEIDENTIFIER
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.types import (TypeDecorator, DateTime, Unicode, CHAR, TEXT, NVARCHAR, VARCHAR,
                               UnicodeText, NUMERIC, TIMESTAMP, DATETIME, JSON)
-from sqlalchemy_hana.dialect import HANAHDBCLIDialect
-from sqlalchemy_greenplum.dialect import GreenplumDialect
-from starrocks.dialect import StarRocksDialect
-from databend_sqlalchemy.databend_dialect import DatabendDialect
+try:
+    from sqlalchemy_hana.dialect import HANAHDBCLIDialect
+except ImportError:
+    HANAHDBCLIDialect = None
+try:
+    from sqlalchemy_greenplum.dialect import GreenplumDialect
+except ImportError:
+    GreenplumDialect = None
+try:
+    from starrocks.dialect import StarRocksDialect
+except ImportError:
+    StarRocksDialect = None
+try:
+    from databend_sqlalchemy.databend_dialect import DatabendDialect
+except ImportError:
+    DatabendDialect = None
 
 from plaidcloud.rpc import config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,19 @@
 bleach
 comtypes;platform_system=="Windows"
-databend-sqlalchemy
+databend_sqlalchemy
 messytables@git+https://github.com/PlaidCloud/messytables.git@master#egg=messytables
 packaging
 psycopg2-binary
-pyjwt
-pyyaml
+PyJWT
+PyYAML
 requests
-requests_futures
+requests-futures
 setuptools
 orjson
-sqlalchemy~=1.4
+SQLAlchemy~=1.4
 sqlalchemy-greenplum
-sqlalchemy-hana
-starrocks
+#sqlalchemy-hana  # moved to test dependencies
+#starrocks  # moved to test dependencies
 toolz
 unicodecsv
 urllib3

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ test_deps = [
     'minimock',
     'pytest-cov',
     'pytest-runner',
+    'sqlalchemy-hana',
+    'starrocks',
 ]
 
 extras = {


### PR DESCRIPTION
Moving these out of real requirements since we don't connect to these databases. We certainly don't need them for a plaid-rpc install usually.