### PR TITLE
Recognize 'any' dtype (map to text)

### DIFF
--- a/plaidcloud/rpc/type_conversion.py
+++ b/plaidcloud/rpc/type_conversion.py
@@ -26,6 +26,7 @@ __maintainer__ = 'Paul Morel'
 __email__ = 'paul.morel@tartansolutions.com'
 
 _ANALYZE_TYPE = regex_map({
+        r'^any$': 'text',  # qsv stats emits "Any" when a column has no homogeneous type — treat as free text
         r'^array$': 'text',
         r'^bool$': 'boolean',
         r'^boolean$': 'boolean',


### PR DESCRIPTION
## Summary
qsv stats emits "Any" for columns where no homogeneous type fits (mixed-content CSV columns with interleaved numeric/string values). `translate_detected_type` was passing `"any"` straight through to `analyze_type`, which raised:

\`\`\`
Unrecognized dtype: 'any'. If you think it's valid, please add it to _ANALYZE_TYPE.
\`\`\`

That exception crashed the `create_table` path in plaid — target table was never created, and every subsequent INSERT against it failed with `"Table not found"`. Reproduced repeatedly on a fresh StarRocks tenant importing a multi-type CSV.

Treat `any` as `text` (the fallback already used for `object`, `string`) so free-form columns import without intervention.

## Test plan
- [x] Regex-map entry matches exactly `any` (case-insensitive via the existing regex normalizer).
- [ ] Fresh CSV import on StarRocks with at least one mixed-content column completes without the "Unrecognized dtype" exception; target analyzetable is created and populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)