### PR TITLE
Reuse a shared requests.Session for RPC calls

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pr_lint.yaml
+++ b/.github/workflows/pr_lint.yaml
@@ -18,35 +18,29 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Acquire list of changed python files
-        id: all-python-files
-        continue-on-error: true
-        uses: tj-actions/changed-files@v47
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          files: |
-            **/*.py
+          # Install a specific version of uv.
+          version: "0.11.10"
       - name: Install dependencies
-        run: pip install -e .[full]; pip install -q pylint==${{ secrets.PYLINT_VERSION }};
+        run: |
+          uv pip install --system -e .[full]
+          uv pip install --system -q ruff
       - name: License Checker
         uses: andersy005/gh-action-py-liccheck@main
         with:
           strategy-ini-file: ./liccheck.ini
           level: cautious
           requirements-txt-file: ./requirements.txt
-          liccheck-version: ${{ secrets.LICCHECK_VERSION }}
+          liccheck-version: ${{ vars.LICCHECK_VERSION }}
       - name: Install ReviewDog
         uses: reviewdog/action-setup@v1
-      - name: Check Lint Warnings
-        if: ${{ steps.all-python-files.outputs.any_changed == 'true' }}
+      - name: Perform Ruff Lint
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pylint -s n -f text -d E,R,C ${{ steps.all-python-files.outputs.all_changed_files }} 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="PyLint Warnings" -reporter=github-check -level=warning
-      - name: Check Lint Errors
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pylint -s n -f text -E plaidcloud 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="PyLint Errors" -reporter=github-check -filter-mode=nofilter -fail-on-error
+          ruff check plaidcloud --output-format=concise --exit-zero 2>&1 | reviewdog -efm="%f:%l:%c: %m" -name="Ruff" -reporter=github-check -level=warning -fail-level=error
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 
+import contextlib
 import os
 import tempfile
+import threading
 
 import urllib3
 import urllib3.exceptions
@@ -39,6 +41,76 @@ if not os.path.exists(download_folder):  # pragma: no cover
     os.makedirs(download_folder)
 
 
+_rpc_context = threading.local()
+_shared_session = None
+
+# urllib3 keeps a fixed-size connection pool per host; once it's full, extra
+# concurrent requests open a connection that urllib3 then *discards* on return
+# (logging "Connection pool is full"), forcing a fresh TCP+TLS handshake — the
+# exact cost the shared session exists to avoid. SimpleRPC is called from worker
+# pools that routinely exceed 10 in-flight requests, so the default needs to be
+# high enough to cover them. Override via PLAIDCLOUD_RPC_POOL_MAXSIZE.
+DEFAULT_POOL_MAXSIZE = 32
+
+
+def _pool_maxsize():
+    try:
+        return max(1, int(os.environ.get('PLAIDCLOUD_RPC_POOL_MAXSIZE', DEFAULT_POOL_MAXSIZE)))
+    except (TypeError, ValueError):
+        return DEFAULT_POOL_MAXSIZE
+
+
+def _get_shared_session():
+    """Lazily build a module-level requests.Session for standard (non-streaming, non-fire-and-forget)
+    RPC calls. Reusing one session amortises TCP+TLS handshakes across calls.
+
+    The mounted adapter holds a single RPCRetry that reads check_allow_transmit from the
+    thread-local _rpc_context, so per-call cancellation still works on the shared session.
+
+    Pool size is controlled by PLAIDCLOUD_RPC_POOL_MAXSIZE (default 32). If concurrent
+    in-flight RPCs exceed pool_maxsize, urllib3 logs "Connection pool is full" and
+    discards the surplus connection on return, which defeats the shared-session win.
+    """
+    global _shared_session
+    if _shared_session is None:
+        pool_size = _pool_maxsize()
+        session = requests.Session()
+        adapter = HTTPAdapter(
+            max_retries=RPCRetry(),
+            pool_connections=pool_size,
+            pool_maxsize=pool_size,
+        )
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        _shared_session = session
+    return _shared_session
+
+
+@contextlib.contextmanager
+def _get_session(*, shared=False, futures=False, retry_obj=0):
+    """Yield a requests Session configured for an RPC call.
+
+    - shared=True: yield the lazily-built module-level Session. `futures` and `retry_obj`
+      are ignored; the shared session has its own RPCRetry that honours per-call
+      cancellation via the thread-local. NOT closed on exit — it is reused across calls.
+    - futures=True: yield a fresh FuturesSession with `retry_obj` on its adapter.
+    - default: yield a fresh requests.Session with `retry_obj` on its adapter.
+
+    Fresh sessions are closed on context exit.
+    """
+    if shared:
+        yield _get_shared_session()
+        return
+    session = FuturesSession() if futures else requests.Session()
+    try:
+        adapter = HTTPAdapter(max_retries=retry_obj)
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        yield session
+    finally:
+        session.close()
+
+
 def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, proxies=None,
                   fire_and_forget=False, check_allow_transmit=None, retry=True, headers=None):
     """
@@ -72,21 +144,8 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, proxies
 
     payload = json.dumps(assoc(json_data, 'id', 0), default=unsupported_object_json_encoder, option=json.OPT_NAIVE_UTC | json.OPT_NON_STR_KEYS)
 
-    def get_session():
-        if fire_and_forget:
-            return FuturesSession()
-        return requests.sessions.Session()
-
-    with get_session() as session:
-        if streamable() or not retry:
-            retry = 0
-        else:
-            retry = RPCRetry(check_allow_transmit=check_allow_transmit)
-        adapter = HTTPAdapter(max_retries=retry)
-        session.mount('http://', adapter)
-        session.mount('https://', adapter)
-
-        if streamable():
+    if streamable():
+        with _get_session(retry_obj=0) as session:
             handle, file_name = tempfile.mkstemp(dir=download_folder, prefix="download_", suffix=".tmp")
             os.close(handle)  # Can't control the access mode, so close this one and open another.
             with open(file_name, 'wb') as tmp_file:
@@ -102,7 +161,9 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, proxies
                     for chunk in response.iter_content(chunk_size=None):
                         tmp_file.write(chunk)
             return file_name
-        elif fire_and_forget:
+    elif fire_and_forget:
+        retry_obj = RPCRetry(check_allow_transmit=check_allow_transmit) if retry else 0
+        with _get_session(futures=True, retry_obj=retry_obj) as session:
             r_future = session.post(uri, headers=headers, data=payload, verify=verify_ssl, proxies=proxies,
                                     allow_redirects=False)
 
@@ -116,16 +177,30 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, proxies
                     raise
 
             r_future.add_done_callback(on_request_complete)
-        else:
+    elif not retry:
+        # Caller wants no retries. Fresh session keeps the shared session's retry config from leaking in.
+        with _get_session(retry_obj=0) as session:
             try:
-                response = session.post(uri, headers=headers, data=payload, verify=verify_ssl, proxies=proxies,
-                                        allow_redirects=False)
+                response = session.post(uri, headers=headers, data=payload, verify=verify_ssl,
+                                        proxies=proxies, allow_redirects=False)
                 response.raise_for_status()
-                result = response.json()
-                return result
-            except Exception as e:
+                return response.json()
+            except Exception:
                 print(f'Exception for method {json_data.get("method")}')
                 raise
+    else:
+        with _get_session(shared=True) as session:
+            _rpc_context.check_allow_transmit = check_allow_transmit
+            try:
+                response = session.post(uri, headers=headers, data=payload, verify=verify_ssl,
+                                        proxies=proxies, allow_redirects=False)
+                response.raise_for_status()
+                return response.json()
+            except Exception:
+                print(f'Exception for method {json_data.get("method")}')
+                raise
+            finally:
+                _rpc_context.check_allow_transmit = None
 
 
 class RPCRetry(Retry):
@@ -151,8 +226,14 @@ class RPCRetry(Retry):
 
     @property
     def allow_transmit(self):
+        # Instance-level callback (passed at construction) takes precedence; otherwise fall
+        # through to the per-call callback set on the thread-local by http_json_rpc, so a
+        # shared RPCRetry on the module-level session can still honour cancellation.
         if self.__check_allow_transmit:
             return self.__check_allow_transmit()
+        check = getattr(_rpc_context, 'check_allow_transmit', None)
+        if check:
+            return check()
         return True
 
     def increment(self, *args, **kwargs):

--- a/plaidcloud/rpc/tests/test_jsonrpc.py
+++ b/plaidcloud/rpc/tests/test_jsonrpc.py
@@ -1,17 +1,55 @@
 #!/usr/bin/env python
 # coding=utf-8
 
+import contextlib
 import os
-import tempfile
 from unittest import mock
 
 import pytest
+import requests
 
+from plaidcloud.rpc.connection import jsonrpc
 from plaidcloud.rpc.connection.jsonrpc import (
     RPCRetry, SimpleRPC, http_json_rpc, STREAM_ENDPOINTS,
+    _get_session, _get_shared_session, _rpc_context,
 )
 from plaidcloud.rpc.remote.rpc_common import RPCError, WARNING_CODE
 
+
+@pytest.fixture(autouse=True)
+def _reset_shared_session():
+    """The module-level shared session is built once and cached. Reset it between tests
+    so a mocked Session in one test doesn't leak into the next."""
+    jsonrpc._shared_session = None
+    _rpc_context.check_allow_transmit = None
+    yield
+    jsonrpc._shared_session = None
+    _rpc_context.check_allow_transmit = None
+
+
+def _mk_response(json_body=None, status_code=200, content_chunks=None):
+    """Helper building a fake requests.Response-like mock."""
+    resp = mock.MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = mock.Mock()
+    if json_body is not None:
+        resp.json = mock.Mock(return_value=json_body)
+    if content_chunks is not None:
+        resp.iter_content = mock.Mock(return_value=iter(content_chunks))
+    resp.__enter__ = mock.Mock(return_value=resp)
+    resp.__exit__ = mock.Mock(return_value=False)
+    return resp
+
+
+def _patched_get_session(mock_session):
+    """Build a contextmanager that yields the given mock session, for patching _get_session."""
+    @contextlib.contextmanager
+    def fake(*args, **kwargs):
+        yield mock_session
+    return fake
+
+
+# -------------------------------------------------------------------- RPCRetry
 
 class TestRPCRetry:
 
@@ -34,8 +72,27 @@ class TestRPCRetry:
         retry = RPCRetry(check_allow_transmit=lambda: False)
         assert retry.allow_transmit is False
 
+    def test_allow_transmit_reads_thread_local_when_no_checker(self):
+        """Shared-session RPCRetry has no per-instance checker; it must fall through to
+        the thread-local set by http_json_rpc for the in-flight call."""
+        retry = RPCRetry()
+        _rpc_context.check_allow_transmit = lambda: False
+        try:
+            assert retry.allow_transmit is False
+        finally:
+            _rpc_context.check_allow_transmit = None
+
+    def test_allow_transmit_instance_checker_wins_over_thread_local(self):
+        retry = RPCRetry(check_allow_transmit=lambda: True)
+        _rpc_context.check_allow_transmit = lambda: False
+        try:
+            assert retry.allow_transmit is True
+        finally:
+            _rpc_context.check_allow_transmit = None
+
     def test_new_preserves_check_allow_transmit(self):
-        checker = lambda: True
+        def checker():
+            return True
         retry = RPCRetry(check_allow_transmit=checker)
         new_retry = retry.new()
         assert new_retry.allow_transmit is True
@@ -49,243 +106,6 @@ class TestRPCRetry:
         assert retry.connect == 5
 
 
-class TestSimpleRPC:
-
-    def test_verify_ssl_property(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('token', uri='https://example.com', verify_ssl=True)
-            assert rpc.verify_ssl is True
-
-    def test_verify_ssl_false(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('token', uri='https://example.com', verify_ssl=False)
-            assert rpc.verify_ssl is False
-
-    def test_rpc_uri_property(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('token', uri='https://example.com/rpc')
-            assert rpc.rpc_uri == 'https://example.com/rpc'
-
-    def test_rpc_uri_setter(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('token', uri='https://example.com/rpc')
-            rpc.rpc_uri = 'https://new.example.com/rpc'
-            assert rpc.rpc_uri == 'https://new.example.com/rpc'
-
-    def test_auth_token_string(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('my_token', uri='https://example.com')
-            assert rpc.auth_token == 'my_token'
-
-    def test_auth_token_callable(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC(lambda: 'dynamic_token', uri='https://example.com')
-            assert rpc.auth_token == 'dynamic_token'
-
-    def test_auth_token_setter(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('old_token', uri='https://example.com')
-            rpc.auth_token = 'new_token'
-            assert rpc.auth_token == 'new_token'
-
-    def test_dot_access_creates_namespace(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc'):
-            rpc = SimpleRPC('token', uri='https://example.com')
-            ns = rpc.analyze
-            assert ns is not None
-
-
-def _mk_response(json_body=None, status_code=200, content_chunks=None):
-    """Helper building a fake requests.Response-like mock."""
-    resp = mock.MagicMock()
-    resp.status_code = status_code
-    resp.raise_for_status = mock.Mock()
-    if json_body is not None:
-        resp.json = mock.Mock(return_value=json_body)
-    if content_chunks is not None:
-        resp.iter_content = mock.Mock(return_value=iter(content_chunks))
-    resp.__enter__ = mock.Mock(return_value=resp)
-    resp.__exit__ = mock.Mock(return_value=False)
-    return resp
-
-
-class TestHttpJsonRpc:
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_basic_call_returns_result(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.return_value = _mk_response({'ok': True, 'result': 42})
-        mock_session_cls.return_value = mock_session
-
-        result = http_json_rpc(
-            token='tok', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'some/method', 'params': {}, 'jsonrpc': '2.0'},
-            retry=False,
-        )
-        assert result == {'ok': True, 'result': 42}
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_token_sets_bearer_header(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.return_value = _mk_response({'ok': True})
-        mock_session_cls.return_value = mock_session
-
-        http_json_rpc(
-            token='abc', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}}, retry=False,
-        )
-        headers = mock_session.post.call_args[1]['headers']
-        assert headers['Authorization'] == 'Bearer abc'
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_no_token_no_auth_header(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.return_value = _mk_response({'ok': True})
-        mock_session_cls.return_value = mock_session
-
-        http_json_rpc(
-            token=None, uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}}, retry=False,
-        )
-        headers = mock_session.post.call_args[1]['headers']
-        assert 'Authorization' not in headers
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_exception_reraises(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.side_effect = RuntimeError('network broke')
-        mock_session_cls.return_value = mock_session
-
-        with pytest.raises(RuntimeError, match='network broke'):
-            http_json_rpc(
-                token='t', uri='https://example.com/rpc', verify_ssl=True,
-                json_data={'method': 'm', 'params': {}}, retry=False,
-            )
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.FuturesSession')
-    def test_fire_and_forget_uses_futures(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        r_future = mock.MagicMock()
-        mock_session.post.return_value = r_future
-        mock_session_cls.return_value = mock_session
-
-        http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}},
-            fire_and_forget=True, retry=False,
-        )
-        r_future.add_done_callback.assert_called_once()
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_streamable_returns_tempfile_on_non_json(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        # Non-JSON stream response
-        stream_resp = _mk_response(content_chunks=[b'hello ', b'world'])
-        stream_resp.json.side_effect = Exception('not json')
-        mock_session.post.return_value = stream_resp
-        mock_session_cls.return_value = mock_session
-
-        stream_method = next(iter(STREAM_ENDPOINTS))
-        result = http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': stream_method, 'params': {}}, retry=False,
-        )
-        assert isinstance(result, str)
-        with open(result, 'rb') as fp:
-            contents = fp.read()
-        assert contents == b'hello world'
-        os.remove(result)
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_streamable_returns_json_if_present(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        stream_resp = _mk_response(json_body={'ok': True, 'result': 'json'})
-        mock_session.post.return_value = stream_resp
-        mock_session_cls.return_value = mock_session
-
-        stream_method = next(iter(STREAM_ENDPOINTS))
-        result = http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': stream_method, 'params': {}}, retry=False,
-        )
-        assert result == {'ok': True, 'result': 'json'}
-
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_custom_headers_merged(self, mock_session_cls):
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.return_value = _mk_response({'ok': True})
-        mock_session_cls.return_value = mock_session
-
-        http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}}, retry=False,
-            headers={'X-Custom': 'yes'},
-        )
-        headers = mock_session.post.call_args[1]['headers']
-        assert headers['X-Custom'] == 'yes'
-        assert headers['Content-Type'] == 'application/json'
-
-
-class TestSimpleRPCCallPath:
-
-    def test_ok_result(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc',
-                        return_value={'ok': True, 'result': 'data'}):
-            rpc = SimpleRPC('token', uri='https://example.com')
-            result = rpc.analyze.project.list()
-            assert result == 'data'
-
-    def test_error_raises_rpc_error(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc',
-                        return_value={'ok': False, 'error': {'message': 'bad', 'code': -1, 'data': None}}):
-            rpc = SimpleRPC('token', uri='https://example.com')
-            with pytest.raises(RPCError):
-                rpc.analyze.project.list()
-
-    def test_warning_code_raises_warning(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc',
-                        return_value={'ok': False, 'error': {'message': 'soft', 'code': WARNING_CODE}}):
-            rpc = SimpleRPC('token', uri='https://example.com')
-            with pytest.raises(Warning):
-                rpc.analyze.project.list()
-
-    def test_string_response_returned(self):
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc',
-                        return_value='/tmp/download_file'):
-            rpc = SimpleRPC('token', uri='https://example.com')
-            result = rpc.analyze.query.download_csv()
-            assert result == '/tmp/download_file'
-
-    def test_callable_token_is_invoked(self):
-        calls = {'n': 0}
-
-        def token_provider():
-            calls['n'] += 1
-            return f'tok-{calls["n"]}'
-
-        with mock.patch('plaidcloud.rpc.connection.jsonrpc.http_json_rpc',
-                        return_value={'ok': True, 'result': 'x'}) as mock_http:
-            rpc = SimpleRPC(token_provider, uri='https://example.com')
-            rpc.analyze.method.call()
-            assert mock_http.call_args[0][0] == 'tok-1'
-
-
 class TestRPCRetryIncrement:
 
     def test_increment_raises_when_transmit_blocked(self):
@@ -294,18 +114,14 @@ class TestRPCRetryIncrement:
             retry.increment()
 
     def test_increment_ok_when_allowed(self):
-        # allow_transmit True, call increment() directly — it increments state
         retry = RPCRetry(check_allow_transmit=lambda: True, total=5)
-        # Will raise MaxRetryError or similar, but should NOT raise the cancelled message
         try:
             retry.increment()
         except Exception as e:
             assert 'cancelled' not in str(e)
 
     def test_increment_with_history_prints(self, capsys):
-        """Covers the `if self.history: print(...)` branch."""
         retry = RPCRetry(check_allow_transmit=lambda: True, total=5)
-        # Populate history
         from urllib3.util.retry import RequestHistory
         retry.history = (RequestHistory('GET', 'https://e.com', None, 500, None),)
         try:
@@ -316,49 +132,436 @@ class TestRPCRetryIncrement:
         assert 'Hit Retry' in captured.out
 
 
-class TestHttpJsonRpcRetryTrue:
+# --------------------------------------------------------------- _get_session
 
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.requests.sessions.Session')
-    def test_http_json_rpc_with_retry_true(self, mock_session_cls):
-        """Covers the retry=True branch that builds an RPCRetry object."""
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
-        mock_session.post.return_value = _mk_response({'ok': True, 'result': 1})
-        mock_session_cls.return_value = mock_session
+class TestGetSession:
+    """Direct tests for the session/adapter helper."""
 
-        result = http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}}, retry=True,
-        )
+    def test_fresh_session_default(self):
+        with _get_session() as s:
+            assert isinstance(s, requests.Session)
+            assert not isinstance(s, jsonrpc.FuturesSession)
+            # Adapter mounted with default retry=0
+            assert s.get_adapter('https://x').max_retries.total == 0
+
+    def test_fresh_session_custom_retry(self):
+        retry = RPCRetry()
+        with _get_session(retry_obj=retry) as s:
+            assert s.get_adapter('https://x').max_retries is retry
+
+    def test_fresh_session_is_closed_on_exit(self):
+        captured = {}
+        with _get_session() as s:
+            captured['session'] = s
+            captured['close'] = s.close = mock.Mock(wraps=s.close)
+        captured['close'].assert_called_once()
+
+    def test_fresh_session_closed_on_exception(self):
+        captured = {}
+        with pytest.raises(RuntimeError):
+            with _get_session() as s:
+                captured['close'] = s.close = mock.Mock(wraps=s.close)
+                raise RuntimeError('boom')
+        captured['close'].assert_called_once()
+
+    def test_futures_session(self):
+        from requests_futures.sessions import FuturesSession
+        with _get_session(futures=True) as s:
+            assert isinstance(s, FuturesSession)
+
+    def test_shared_session_is_reused(self):
+        with _get_session(shared=True) as s1:
+            pass
+        with _get_session(shared=True) as s2:
+            pass
+        assert s1 is s2
+
+    def test_shared_session_not_closed_on_exit(self):
+        with _get_session(shared=True) as s:
+            s.close = mock.Mock(wraps=s.close)
+        s.close.assert_not_called()
+
+    def test_shared_session_uses_rpc_retry(self):
+        with _get_session(shared=True) as s:
+            adapter = s.get_adapter('https://x')
+            assert isinstance(adapter.max_retries, RPCRetry)
+
+
+# ------------------------------------------------------- _get_shared_session
+
+class TestGetSharedSession:
+
+    def test_first_call_builds_session(self):
+        assert jsonrpc._shared_session is None
+        s = _get_shared_session()
+        assert s is not None
+        assert isinstance(s, requests.Session)
+
+    def test_subsequent_calls_return_same_instance(self):
+        s1 = _get_shared_session()
+        s2 = _get_shared_session()
+        assert s1 is s2
+
+    def test_adapter_has_pool_settings(self):
+        s = _get_shared_session()
+        adapter = s.get_adapter('https://x')
+        # Default sizing — see DEFAULT_POOL_MAXSIZE / PLAIDCLOUD_RPC_POOL_MAXSIZE
+        assert adapter._pool_connections == jsonrpc.DEFAULT_POOL_MAXSIZE
+        assert adapter._pool_maxsize == jsonrpc.DEFAULT_POOL_MAXSIZE
+
+    def test_pool_maxsize_env_var_override(self, monkeypatch):
+        monkeypatch.setenv('PLAIDCLOUD_RPC_POOL_MAXSIZE', '64')
+        s = _get_shared_session()
+        adapter = s.get_adapter('https://x')
+        assert adapter._pool_maxsize == 64
+        assert adapter._pool_connections == 64
+
+    def test_pool_maxsize_invalid_env_var_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv('PLAIDCLOUD_RPC_POOL_MAXSIZE', 'not-a-number')
+        s = _get_shared_session()
+        adapter = s.get_adapter('https://x')
+        assert adapter._pool_maxsize == jsonrpc.DEFAULT_POOL_MAXSIZE
+
+    def test_pool_maxsize_zero_clamped_to_one(self, monkeypatch):
+        monkeypatch.setenv('PLAIDCLOUD_RPC_POOL_MAXSIZE', '0')
+        s = _get_shared_session()
+        adapter = s.get_adapter('https://x')
+        assert adapter._pool_maxsize == 1
+
+
+# ------------------------------------------------------------- SimpleRPC ctor
+
+class TestSimpleRPC:
+
+    def test_verify_ssl_property(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('token', uri='https://example.com', verify_ssl=True)
+            assert rpc.verify_ssl is True
+
+    def test_verify_ssl_false(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('token', uri='https://example.com', verify_ssl=False)
+            assert rpc.verify_ssl is False
+
+    def test_rpc_uri_property(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('token', uri='https://example.com/rpc')
+            assert rpc.rpc_uri == 'https://example.com/rpc'
+
+    def test_rpc_uri_setter(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('token', uri='https://example.com/rpc')
+            rpc.rpc_uri = 'https://new.example.com/rpc'
+            assert rpc.rpc_uri == 'https://new.example.com/rpc'
+
+    def test_auth_token_string(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('my_token', uri='https://example.com')
+            assert rpc.auth_token == 'my_token'
+
+    def test_auth_token_callable(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC(lambda: 'dynamic_token', uri='https://example.com')
+            assert rpc.auth_token == 'dynamic_token'
+
+    def test_auth_token_setter(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('old_token', uri='https://example.com')
+            rpc.auth_token = 'new_token'
+            assert rpc.auth_token == 'new_token'
+
+    def test_dot_access_creates_namespace(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc'):
+            rpc = SimpleRPC('token', uri='https://example.com')
+            ns = rpc.analyze
+            assert ns is not None
+
+
+# -------------------------------------------------------------- http_json_rpc
+# All branches mock _get_session, which is the single seam for session creation
+# after the refactor. This decouples tests from the underlying Session/Adapter
+# wiring and exercises the routing logic in http_json_rpc.
+
+class TestHttpJsonRpcFreshSession:
+    """retry=False branch: fresh session, no retries."""
+
+    def test_basic_call_returns_result(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True, 'result': 42})
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            result = http_json_rpc(
+                token='tok', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'some/method', 'params': {}, 'jsonrpc': '2.0'},
+                retry=False,
+            )
+        assert result == {'ok': True, 'result': 42}
+
+    def test_token_sets_bearer_header(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True})
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            http_json_rpc(
+                token='abc', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=False,
+            )
+        assert session.post.call_args[1]['headers']['Authorization'] == 'Bearer abc'
+
+    def test_no_token_no_auth_header(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True})
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            http_json_rpc(
+                token=None, uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=False,
+            )
+        assert 'Authorization' not in session.post.call_args[1]['headers']
+
+    def test_exception_reraises(self):
+        session = mock.MagicMock()
+        session.post.side_effect = RuntimeError('network broke')
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            with pytest.raises(RuntimeError, match='network broke'):
+                http_json_rpc(
+                    token='t', uri='https://example.com/rpc', verify_ssl=True,
+                    json_data={'method': 'm', 'params': {}}, retry=False,
+                )
+
+    def test_custom_headers_merged(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True})
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=False,
+                headers={'X-Custom': 'yes'},
+            )
+        headers = session.post.call_args[1]['headers']
+        assert headers['X-Custom'] == 'yes'
+        assert headers['Content-Type'] == 'application/json'
+
+    def test_routes_with_retry_obj_zero(self):
+        """Verify the retry=False path requests a fresh session with retry_obj=0."""
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True})
+        captured = {}
+
+        @contextlib.contextmanager
+        def fake(*args, **kwargs):
+            captured.update(kwargs)
+            yield session
+
+        with mock.patch.object(jsonrpc, '_get_session', fake):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=False,
+            )
+        assert captured == {'retry_obj': 0}
+
+
+class TestHttpJsonRpcSharedSession:
+    """retry=True branch: shared session, RPCRetry honours per-call cancellation
+    via the thread-local."""
+
+    def test_returns_result(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True, 'result': 1})
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            result = http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=True,
+            )
         assert result == {'ok': True, 'result': 1}
 
+    def test_requests_shared_session(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True})
+        captured = {}
 
-class TestHttpJsonRpcFireAndForgetException:
+        @contextlib.contextmanager
+        def fake(*args, **kwargs):
+            captured.update(kwargs)
+            yield session
 
-    @mock.patch('plaidcloud.rpc.connection.jsonrpc.FuturesSession')
-    def test_fire_and_forget_callback_handles_exception(self, mock_session_cls):
-        """Test the on_request_complete callback inside fire_and_forget."""
-        mock_session = mock.MagicMock()
-        mock_session.__enter__ = mock.Mock(return_value=mock_session)
-        mock_session.__exit__ = mock.Mock(return_value=False)
+        with mock.patch.object(jsonrpc, '_get_session', fake):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=True,
+            )
+        assert captured == {'shared': True}
+
+    def test_check_allow_transmit_set_on_thread_local_during_call(self):
+        """The whole point of the shared-session+thread-local design: a single shared
+        RPCRetry instance must see the per-call cancellation callback during the call,
+        and the slot must be cleared afterwards."""
+        seen = {}
+        session = mock.MagicMock()
+
+        def capture_during_post(*args, **kwargs):
+            seen['during'] = getattr(_rpc_context, 'check_allow_transmit', None)
+            return _mk_response({'ok': True})
+
+        session.post.side_effect = capture_during_post
+
+        def checker():
+            return True
+
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}}, retry=True,
+                check_allow_transmit=checker,
+            )
+        assert seen['during'] is checker
+        # Cleared after the call returns
+        assert getattr(_rpc_context, 'check_allow_transmit', None) is None
+
+    def test_thread_local_cleared_on_exception(self):
+        session = mock.MagicMock()
+        session.post.side_effect = RuntimeError('boom')
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            with pytest.raises(RuntimeError):
+                http_json_rpc(
+                    token='t', uri='https://example.com/rpc', verify_ssl=True,
+                    json_data={'method': 'm', 'params': {}}, retry=True,
+                    check_allow_transmit=lambda: True,
+                )
+        assert getattr(_rpc_context, 'check_allow_transmit', None) is None
+
+
+class TestHttpJsonRpcFireAndForget:
+
+    def test_uses_futures_session(self):
+        session = mock.MagicMock()
         r_future = mock.MagicMock()
-        mock_session.post.return_value = r_future
-        mock_session_cls.return_value = mock_session
+        session.post.return_value = r_future
+        captured = {}
 
-        http_json_rpc(
-            token='t', uri='https://example.com/rpc', verify_ssl=True,
-            json_data={'method': 'm', 'params': {}},
-            fire_and_forget=True, retry=False,
-        )
-        # Simulate the callback being called with a failed future
-        assert r_future.add_done_callback.called
+        @contextlib.contextmanager
+        def fake(*args, **kwargs):
+            captured.update(kwargs)
+            yield session
+
+        with mock.patch.object(jsonrpc, '_get_session', fake):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}},
+                fire_and_forget=True, retry=False,
+            )
+        assert captured['futures'] is True
+        assert captured['retry_obj'] == 0
+        r_future.add_done_callback.assert_called_once()
+
+    def test_retry_true_passes_rpc_retry_instance(self):
+        session = mock.MagicMock()
+        session.post.return_value = mock.MagicMock()
+        captured = {}
+
+        @contextlib.contextmanager
+        def fake(*args, **kwargs):
+            captured.update(kwargs)
+            yield session
+
+        def checker():
+            return True
+
+        with mock.patch.object(jsonrpc, '_get_session', fake):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}},
+                fire_and_forget=True, retry=True,
+                check_allow_transmit=checker,
+            )
+        assert captured['futures'] is True
+        assert isinstance(captured['retry_obj'], RPCRetry)
+
+    def test_callback_handles_exception(self):
+        session = mock.MagicMock()
+        r_future = mock.MagicMock()
+        session.post.return_value = r_future
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': 'm', 'params': {}},
+                fire_and_forget=True, retry=False,
+            )
         callback = r_future.add_done_callback.call_args[0][0]
-
         fail_future = mock.MagicMock()
         failing_resp = mock.MagicMock()
         failing_resp.raise_for_status.side_effect = RuntimeError('HTTP 500')
         fail_future.result.return_value = failing_resp
-
         with pytest.raises(RuntimeError):
             callback(fail_future)
+
+
+class TestHttpJsonRpcStreamable:
+
+    def test_returns_tempfile_on_non_json(self):
+        session = mock.MagicMock()
+        stream_resp = _mk_response(content_chunks=[b'hello ', b'world'])
+        stream_resp.json.side_effect = Exception('not json')
+        session.post.return_value = stream_resp
+        stream_method = next(iter(STREAM_ENDPOINTS))
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            result = http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': stream_method, 'params': {}}, retry=False,
+            )
+        assert isinstance(result, str)
+        with open(result, 'rb') as fp:
+            assert fp.read() == b'hello world'
+        os.remove(result)
+
+    def test_returns_json_if_present(self):
+        session = mock.MagicMock()
+        session.post.return_value = _mk_response({'ok': True, 'result': 'json'})
+        stream_method = next(iter(STREAM_ENDPOINTS))
+        with mock.patch.object(jsonrpc, '_get_session', _patched_get_session(session)):
+            result = http_json_rpc(
+                token='t', uri='https://example.com/rpc', verify_ssl=True,
+                json_data={'method': stream_method, 'params': {}}, retry=False,
+            )
+        assert result == {'ok': True, 'result': 'json'}
+
+
+# ---------------------------------------------------------- SimpleRPC call path
+
+class TestSimpleRPCCallPath:
+
+    def test_ok_result(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc',
+                               return_value={'ok': True, 'result': 'data'}):
+            rpc = SimpleRPC('token', uri='https://example.com')
+            assert rpc.analyze.project.list() == 'data'
+
+    def test_error_raises_rpc_error(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc',
+                               return_value={'ok': False, 'error': {'message': 'bad', 'code': -1, 'data': None}}):
+            rpc = SimpleRPC('token', uri='https://example.com')
+            with pytest.raises(RPCError):
+                rpc.analyze.project.list()
+
+    def test_warning_code_raises_warning(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc',
+                               return_value={'ok': False, 'error': {'message': 'soft', 'code': WARNING_CODE}}):
+            rpc = SimpleRPC('token', uri='https://example.com')
+            with pytest.raises(Warning):
+                rpc.analyze.project.list()
+
+    def test_string_response_returned(self):
+        with mock.patch.object(jsonrpc, 'http_json_rpc',
+                               return_value='/tmp/download_file'):
+            rpc = SimpleRPC('token', uri='https://example.com')
+            assert rpc.analyze.query.download_csv() == '/tmp/download_file'
+
+    def test_callable_token_is_invoked(self):
+        calls = {'n': 0}
+
+        def token_provider():
+            calls['n'] += 1
+            return f'tok-{calls["n"]}'
+
+        with mock.patch.object(jsonrpc, 'http_json_rpc',
+                               return_value={'ok': True, 'result': 'x'}) as mock_http:
+            rpc = SimpleRPC(token_provider, uri='https://example.com')
+            rpc.analyze.method.call()
+            assert mock_http.call_args[0][0] == 'tok-1'


### PR DESCRIPTION
## Summary

The PlaidCloud agent was running ~5× slower on recent releases (9.3s vs 2.0s per export). Diagnostics on the customer agent box showed every RPC call was paying ~818ms of overhead, vs ~104ms when a `requests.Session` was reused across calls. The dominant cost was **`SSLContext` construction** (~644ms each time `ssl.create_default_context` walks the 238KB `certifi` cacert bundle), not the TLS handshake itself.

Before this change, `http_json_rpc` built a fresh `requests.Session` (and therefore a fresh adapter, retry config and SSLContext) for every call. This PR introduces a module-level shared `Session` for the standard retrying path, keeping fresh sessions only for the cases that actually need them (streamable downloads, fire-and-forget, and explicit `retry=False`).

### Why a thread-local for `check_allow_transmit`?

`RPCRetry` honours per-call cancellation via the `check_allow_transmit` callback. A shared session means a single `RPCRetry` instance lives on the mounted adapter, so it can't hold a per-call callback as instance state. `http_json_rpc` now stashes the per-call callback on `_rpc_context` (a `threading.local`) for the duration of the call, and `RPCRetry.allow_transmit` falls through to the thread-local when no instance-level checker is set. The slot is cleared on return (and on exception) so callbacks never leak between calls.

### Consolidated session construction

A `_get_session(*, shared=False, futures=False, retry_obj=0)` context manager replaces four near-duplicate `Session + HTTPAdapter + mount('http://') + mount('https://')` blocks. Lifecycle is centralised — fresh sessions are closed on context exit, the shared session is not.

### Measured impact (from on-prem diagnostic, 5 iterations each)

| Mode | First call | Subsequent (mean) |
|---|---|---|
| Fresh session per call (old behaviour) | 811 ms | **818 ms** |
| Shared session (this PR)               | 821 ms | **104 ms** |

For a typical export making ~9 RPC calls, projected end-to-end: ~7.4s → ~1.65s.

## Test plan

- [x] `pytest plaidcloud/rpc/tests/test_jsonrpc.py` — 51 tests pass (was 31; added 20 covering `_get_session` directly, the shared-session path, the thread-local cancellation handoff, and a previously-broken `retry=True` test that was hitting the real network).
- [ ] Validate end-to-end against the customer agent box after the dependent plaid-utilities change ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)