### PR TITLE
fix: surface the real exception in unexpected RPC errors (sc-22705)

### DIFF
--- a/plaidcloud/rpc/remote/rpc_common.py
+++ b/plaidcloud/rpc/remote/rpc_common.py
@@ -192,8 +192,10 @@ def rpc_method(required_scope=None, default_error=None, is_streamed=False, use_t
 
 async def call_as_coroutine(function, default_error, use_thread, is_streamed, system_user, logger, **kwargs):
     def _get_error_message(exc: Exception):
-        # Hide most of the traceback, but provide useful diagnostic info
-        user_hint = traceback.format_exception(exc, limit=-1)[0]
+        # Show the exception type and message but not the stack frames — enough to
+        # diagnose without leaking the traceback to the user. (format_exception(..)[0]
+        # is the "Traceback (most recent call last):" header, not the message.)
+        user_hint = ''.join(traceback.format_exception_only(exc)).strip()
         return f'{f"Unexpected error: {user_hint}" if not default_error else default_error}'
     try:
         if asyncio.iscoroutinefunction(function):

--- a/plaidcloud/rpc/tests/remote/test_rpc_common.py
+++ b/plaidcloud/rpc/tests/remote/test_rpc_common.py
@@ -274,6 +274,18 @@ class TestCallAsCoroutine:
         assert result is None
         assert err['message'] == 'generic error'
 
+    def test_unexpected_error_message_is_exception_not_traceback_header(self):
+        # With no default_error, the surfaced message must be the exception type +
+        # text, never the "Traceback (most recent call last):" header (sc-22705).
+        def fn():
+            raise RuntimeError('something broke')
+
+        logger = logging.getLogger('test')
+        result, err = self._run(fn, None, False, False, False, logger)
+        assert result is None
+        assert err['message'] == 'Unexpected error: RuntimeError: something broke'
+        assert 'Traceback (most recent call last)' not in err['message']
+
     def test_async_not_implemented_wrapped(self):
         # Inner try/except wraps all exceptions to -32603 for async fns
         async def fn():

--- a/plaidcloud/rpc/tests/remote/test_rpc_common.py
+++ b/plaidcloud/rpc/tests/remote/test_rpc_common.py
@@ -286,6 +286,18 @@ class TestCallAsCoroutine:
         assert err['message'] == 'Unexpected error: RuntimeError: something broke'
         assert 'Traceback (most recent call last)' not in err['message']
 
+    def test_async_unexpected_error_message_is_exception_not_traceback_header(self):
+        # Same guarantee via the async coroutine branch, which also calls
+        # _get_error_message (sc-22705).
+        async def fn():
+            raise RuntimeError('async broke')
+
+        logger = logging.getLogger('test')
+        result, err = self._run(fn, None, False, False, False, logger)
+        assert result is None
+        assert err['message'] == 'Unexpected error: RuntimeError: async broke'
+        assert 'Traceback (most recent call last)' not in err['message']
+
     def test_async_not_implemented_wrapped(self):
         # Inner try/except wraps all exceptions to -32603 for async fns
         async def fn():


### PR DESCRIPTION
## What

`call_as_coroutine._get_error_message` built the user-facing message from `traceback.format_exception(exc, limit=-1)[0]` — but `[0]` is the `"Traceback (most recent call last):"` header line, not the exception text. So **every** unhandled RPC error reached callers as:

```
RPCError: Unexpected error: Traceback (most recent call last):
```

with the actual cause stripped — this is the reporting half of sc-22705.

## Fix

Use `traceback.format_exception_only(exc)` — the exception type + message, with **no stack frames**, so the traceback still isn't leaked to the user (preserving the original truncation intent).

Before → after for the sc-22705 trigger (a Superset 422):
- before: `Unexpected error: Traceback (most recent call last):`
- after: `Unexpected error: ClientResponseError: 422, message="Superset error: {... already exists ...}", url=...`

Adds a regression test (`test_unexpected_error_message_is_exception_not_traceback_header`); the full `TestCallAsCoroutine` suite passes (11/11).

## Consuming side

Once tagged `v1.7.3`, plaid's `requirements.txt` pin moves `plaidcloud-rpc[full]` `1.7.0 → 1.7.3` (prepared on plaid's `sc-22705` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)