### PR TITLE
Add OpenTelemetry tracing bootstrap and client trace-context injection

### DIFF
--- a/plaidcloud/rpc/connection/jsonrpc.py
+++ b/plaidcloud/rpc/connection/jsonrpc.py
@@ -20,6 +20,7 @@ from toolz.dicttoolz import assoc
 from plaidcloud.rpc.orjson import unsupported_object_json_encoder
 from plaidcloud.rpc.remote.rpc_tools import PlainRPCCommon
 from plaidcloud.rpc.remote.rpc_common import RPCError, WARNING_CODE
+from plaidcloud.rpc.telemetry import inject_trace_context
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -141,6 +142,11 @@ def http_json_rpc(token=None, uri=None, verify_ssl=None, json_data=None, proxies
     headers["Content-Type"] = "application/json"
     if token:
         headers["Authorization"] = auth_header()
+
+    # Inject W3C trace context so the RPC server can stitch this hop into the caller's
+    # trace. Runs in the calling coroutine before any FuturesSession/thread handoff, so it
+    # covers both sync and fire_and_forget paths. No-op when no tracer provider/active span.
+    inject_trace_context(headers)
 
     payload = json.dumps(assoc(json_data, 'id', 0), default=unsupported_object_json_encoder, option=json.OPT_NAIVE_UTC | json.OPT_NON_STR_KEYS)
 

--- a/plaidcloud/rpc/telemetry.py
+++ b/plaidcloud/rpc/telemetry.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+"""OpenTelemetry tracing bootstrap for PlaidCloud services.
+
+Single-tenant per process: each RPC pod serves one tenant, so a static
+``X-Scope-OrgID`` (the pod's own ``pw-<tenant>``/``ps-<tenant>`` namespace) is set
+once at startup and rides every span export. Inert unless ``PLAID_TRACING_ENABLED``
+is true — importing this module has no effect until ``init_tracing`` is called.
+"""
+
+import os
+
+_DOWNWARD_API_NAMESPACE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+
+def _pod_namespace():
+    """The pod's own K8s namespace, from the downward-API file then POD_NAMESPACE env."""
+    try:
+        with open(_DOWNWARD_API_NAMESPACE) as ns:
+            return ns.read().strip()
+    except (FileNotFoundError, PermissionError):
+        return os.environ.get("POD_NAMESPACE", "").strip()
+
+
+def telemetry_org_id():
+    """The Tempo/Loki multitenancy org-id for this process.
+
+    Equals the pod namespace (``pw-<tenant>`` / ``ps-<tenant>``) — exactly what the
+    per-tenant Grafana datasource reads and what Promtail tags logs with, so traces,
+    logs, and reads share one org by construction. Non-tenant (control-plane/infra)
+    processes fall back to ``admins``.
+    """
+    ns = _pod_namespace()
+    return ns if ns.startswith(("pw-", "ps-")) else "admins"
+
+
+def tracing_enabled():
+    return os.environ.get("PLAID_TRACING_ENABLED", "false").lower() == "true"
+
+
+def init_tracing(service_name, org_id=None):
+    """Install a global TracerProvider exporting to Tempo over OTLP gRPC.
+
+    Call once per process at startup. No-op (returns False) when tracing is disabled.
+    ``org_id`` overrides the resolved org-id — pass it when the caller derives the
+    tenant differently (e.g. cp-rest), otherwise ``telemetry_org_id()`` is used.
+    """
+    if not tracing_enabled():
+        return False
+
+    # Imported lazily so the SDK is not a hard import cost for every plaidcloud.rpc user.
+    from opentelemetry import trace
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+    org = org_id or telemetry_org_id()
+    endpoint = os.environ.get(
+        "PLAID_TRACING_OTLP_ENDPOINT", "tempo-distributor.cluster-components.svc:4317"
+    )
+    ratio = float(os.environ.get("PLAID_TRACING_SAMPLE_RATIO", "0.05"))
+
+    provider = TracerProvider(
+        resource=Resource.create({
+            "service.name": service_name,
+            "service.namespace": org,
+            "tenant.id": org,
+        }),
+        sampler=ParentBased(TraceIdRatioBased(ratio)),
+    )
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(
+        endpoint=endpoint,
+        insecure=True,                          # in-cluster, no TLS
+        headers=(("x-scope-orgid", org),),      # gRPC metadata is lowercase
+    )))
+    trace.set_tracer_provider(provider)
+    return True
+
+
+def inject_trace_context(carrier):
+    """Inject W3C traceparent/tracestate into a header dict. No-op with no active span,
+    so it is safe to call unconditionally on every outbound RPC."""
+    from opentelemetry import propagate
+
+    propagate.inject(carrier)
+
+
+def shutdown_tracing():
+    """Flush and shut down the tracer provider — required in short-lived processes
+    (e.g. workflow-runner K8s Jobs) so the BatchSpanProcessor exports before exit."""
+    from opentelemetry import trace
+
+    provider = trace.get_tracer_provider()
+    shutdown = getattr(provider, "shutdown", None)
+    if shutdown is not None:
+        shutdown()

--- a/plaidcloud/rpc/telemetry.py
+++ b/plaidcloud/rpc/telemetry.py
@@ -16,11 +16,13 @@ _initialized = False
 
 
 def _pod_namespace():
-    """The pod's own K8s namespace, from the downward-API file then POD_NAMESPACE env."""
+    """The pod's own K8s namespace, from the downward-API file then POD_NAMESPACE env.
+    Any read failure falls back to the env var — this runs during startup and must not
+    crash the process."""
     try:
         with open(_DOWNWARD_API_NAMESPACE) as ns:
             return ns.read().strip()
-    except (FileNotFoundError, PermissionError):
+    except OSError:
         return os.environ.get("POD_NAMESPACE", "").strip()
 
 
@@ -59,6 +61,9 @@ def init_tracing(service_name, org_id=None):
     ``org_id`` overrides the resolved org-id — pass it when the caller derives the tenant
     differently (e.g. cp-rest), otherwise ``telemetry_org_id()`` is used.
     """
+    # Called once at process startup before request handling, so the check-then-set on
+    # _initialized is not guarded by a lock; the OTel provider's own set-once guard is the
+    # backstop if that assumption is ever violated.
     global _initialized
     if not tracing_enabled():
         return False
@@ -98,8 +103,11 @@ def init_tracing(service_name, org_id=None):
 
 
 def inject_trace_context(carrier):
-    """Inject W3C traceparent/tracestate into a header dict. No-op with no active span,
-    so it is safe to call unconditionally on every outbound RPC."""
+    """Inject W3C traceparent/tracestate into a header dict. Zero-cost (returns before
+    importing/using OTel) unless init_tracing has installed a provider, so it is safe to
+    call unconditionally on every outbound RPC even when tracing is disabled."""
+    if not _initialized:
+        return
     from opentelemetry import propagate
 
     propagate.inject(carrier)

--- a/plaidcloud/rpc/telemetry.py
+++ b/plaidcloud/rpc/telemetry.py
@@ -10,6 +10,9 @@ is true — importing this module has no effect until ``init_tracing`` is called
 import os
 
 _DOWNWARD_API_NAMESPACE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+_DEFAULT_SAMPLE_RATIO = 0.05
+
+_initialized = False
 
 
 def _pod_namespace():
@@ -37,15 +40,30 @@ def tracing_enabled():
     return os.environ.get("PLAID_TRACING_ENABLED", "false").lower() == "true"
 
 
+def _sample_ratio():
+    """Sampling ratio from PLAID_TRACING_SAMPLE_RATIO, clamped to [0, 1]; a malformed
+    value falls back to the default rather than crashing the service at startup."""
+    try:
+        ratio = float(os.environ.get("PLAID_TRACING_SAMPLE_RATIO", _DEFAULT_SAMPLE_RATIO))
+    except ValueError:
+        return _DEFAULT_SAMPLE_RATIO
+    return min(1.0, max(0.0, ratio))
+
+
 def init_tracing(service_name, org_id=None):
     """Install a global TracerProvider exporting to Tempo over OTLP gRPC.
 
-    Call once per process at startup. No-op (returns False) when tracing is disabled.
-    ``org_id`` overrides the resolved org-id — pass it when the caller derives the
-    tenant differently (e.g. cp-rest), otherwise ``telemetry_org_id()`` is used.
+    Call once per process at startup. Returns True if tracing is active (this call or a
+    prior one installed the provider), False when disabled. Idempotent: a second call is a
+    no-op — OTel's provider is process-wide set-once, so re-installing would silently fail.
+    ``org_id`` overrides the resolved org-id — pass it when the caller derives the tenant
+    differently (e.g. cp-rest), otherwise ``telemetry_org_id()`` is used.
     """
+    global _initialized
     if not tracing_enabled():
         return False
+    if _initialized:
+        return True
 
     # Imported lazily so the SDK is not a hard import cost for every plaidcloud.rpc user.
     from opentelemetry import trace
@@ -59,7 +77,7 @@ def init_tracing(service_name, org_id=None):
     endpoint = os.environ.get(
         "PLAID_TRACING_OTLP_ENDPOINT", "tempo-distributor.cluster-components.svc:4317"
     )
-    ratio = float(os.environ.get("PLAID_TRACING_SAMPLE_RATIO", "0.05"))
+    ratio = _sample_ratio()
 
     provider = TracerProvider(
         resource=Resource.create({
@@ -75,6 +93,7 @@ def init_tracing(service_name, org_id=None):
         headers=(("x-scope-orgid", org),),      # gRPC metadata is lowercase
     )))
     trace.set_tracer_provider(provider)
+    _initialized = True
     return True
 
 

--- a/plaidcloud/rpc/tests/test_telemetry.py
+++ b/plaidcloud/rpc/tests/test_telemetry.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+from unittest import mock
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+
+from plaidcloud.rpc import telemetry
+
+
+def test_pod_namespace_reads_downward_api_file():
+    m = mock.mock_open(read_data=" pw-tartan \n")
+    with mock.patch("builtins.open", m):
+        assert telemetry._pod_namespace() == "pw-tartan"
+
+
+def test_pod_namespace_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("POD_NAMESPACE", "ps-tartan")
+    with mock.patch("builtins.open", side_effect=FileNotFoundError):
+        assert telemetry._pod_namespace() == "ps-tartan"
+
+
+def test_org_id_production_namespace(monkeypatch):
+    monkeypatch.setattr(telemetry, "_pod_namespace", lambda: "pw-tartan")
+    assert telemetry.telemetry_org_id() == "pw-tartan"
+
+
+def test_org_id_sandbox_namespace(monkeypatch):
+    monkeypatch.setattr(telemetry, "_pod_namespace", lambda: "ps-tartan")
+    assert telemetry.telemetry_org_id() == "ps-tartan"
+
+
+def test_org_id_non_tenant_is_admins(monkeypatch):
+    monkeypatch.setattr(telemetry, "_pod_namespace", lambda: "cluster-components")
+    assert telemetry.telemetry_org_id() == "admins"
+
+
+def test_tracing_enabled_flag(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "TRUE")
+    assert telemetry.tracing_enabled() is True
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "false")
+    assert telemetry.tracing_enabled() is False
+
+
+def test_init_tracing_noop_when_disabled(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "false")
+    assert telemetry.init_tracing("svc") is False
+
+
+def test_init_tracing_installs_provider(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "pw-tartan")
+    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "1.0")
+    with mock.patch(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
+    ) as exporter, mock.patch(
+        "opentelemetry.sdk.trace.export.BatchSpanProcessor"
+    ), mock.patch("opentelemetry.trace.set_tracer_provider") as set_provider:
+        assert telemetry.init_tracing("plaid-rpc-test") is True
+        # org-id flows into the exporter as lowercase gRPC metadata
+        _, kwargs = exporter.call_args
+        assert kwargs["headers"] == (("x-scope-orgid", "pw-tartan"),)
+        assert set_provider.called
+
+
+def test_inject_is_noop_without_active_span():
+    carrier = {}
+    telemetry.inject_trace_context(carrier)
+    assert "traceparent" not in carrier
+
+
+def test_inject_writes_traceparent_under_active_span():
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    tracer = provider.get_tracer("test")
+    carrier = {}
+    with trace.use_span(tracer.start_span("s"), end_on_exit=True):
+        telemetry.inject_trace_context(carrier)
+    assert "traceparent" in carrier
+
+
+def test_shutdown_flushes_provider():
+    provider = mock.Mock()
+    with mock.patch("opentelemetry.trace.get_tracer_provider", return_value=provider):
+        telemetry.shutdown_tracing()
+    provider.shutdown.assert_called_once()
+
+
+def test_shutdown_tolerates_provider_without_shutdown():
+    class _NoShutdown:
+        pass
+    with mock.patch("opentelemetry.trace.get_tracer_provider", return_value=_NoShutdown()):
+        telemetry.shutdown_tracing()   # must not raise

--- a/plaidcloud/rpc/tests/test_telemetry.py
+++ b/plaidcloud/rpc/tests/test_telemetry.py
@@ -111,13 +111,22 @@ def test_init_tracing_is_idempotent(monkeypatch):
     assert not set_provider.called
 
 
-def test_inject_is_noop_without_active_span():
+def test_inject_skipped_when_not_initialized():
+    telemetry._initialized = False
+    carrier = {}
+    telemetry.inject_trace_context(carrier)
+    assert carrier == {}
+
+
+def test_inject_is_noop_without_active_span_when_initialized():
+    telemetry._initialized = True
     carrier = {}
     telemetry.inject_trace_context(carrier)
     assert "traceparent" not in carrier
 
 
 def test_inject_writes_traceparent_under_active_span():
+    telemetry._initialized = True
     provider = TracerProvider(sampler=ALWAYS_ON)
     tracer = provider.get_tracer("test")
     carrier = {}

--- a/plaidcloud/rpc/tests/test_telemetry.py
+++ b/plaidcloud/rpc/tests/test_telemetry.py
@@ -3,11 +3,20 @@
 
 from unittest import mock
 
+import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 
 from plaidcloud.rpc import telemetry
+
+
+@pytest.fixture(autouse=True)
+def _reset_initialized():
+    """init_tracing is idempotent via a module-level flag; reset it between tests."""
+    telemetry._initialized = False
+    yield
+    telemetry._initialized = False
 
 
 def test_pod_namespace_reads_downward_api_file():
@@ -49,20 +58,57 @@ def test_init_tracing_noop_when_disabled(monkeypatch):
     assert telemetry.init_tracing("svc") is False
 
 
-def test_init_tracing_installs_provider(monkeypatch):
-    monkeypatch.setenv("PLAID_TRACING_ENABLED", "true")
-    monkeypatch.setenv("POD_NAMESPACE", "pw-tartan")
-    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "1.0")
+def test_sample_ratio_default_clamp_and_malformed(monkeypatch):
+    monkeypatch.delenv("PLAID_TRACING_SAMPLE_RATIO", raising=False)
+    assert telemetry._sample_ratio() == 0.05
+    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "0.5")
+    assert telemetry._sample_ratio() == 0.5
+    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "9")     # clamps to 1.0
+    assert telemetry._sample_ratio() == 1.0
+    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "-3")    # clamps to 0.0
+    assert telemetry._sample_ratio() == 0.0
+    monkeypatch.setenv("PLAID_TRACING_SAMPLE_RATIO", "notafloat")  # falls back
+    assert telemetry._sample_ratio() == 0.05
+
+
+def _install_and_capture(service="plaid-rpc-test", org_id=None):
     with mock.patch(
         "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
     ) as exporter, mock.patch(
         "opentelemetry.sdk.trace.export.BatchSpanProcessor"
     ), mock.patch("opentelemetry.trace.set_tracer_provider") as set_provider:
-        assert telemetry.init_tracing("plaid-rpc-test") is True
-        # org-id flows into the exporter as lowercase gRPC metadata
-        _, kwargs = exporter.call_args
-        assert kwargs["headers"] == (("x-scope-orgid", "pw-tartan"),)
-        assert set_provider.called
+        result = telemetry.init_tracing(service, org_id=org_id)
+        return result, exporter, set_provider
+
+
+def test_init_tracing_installs_provider(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "pw-tartan")
+    result, exporter, set_provider = _install_and_capture()
+    assert result is True
+    # org-id flows into the exporter as lowercase gRPC metadata
+    _, kwargs = exporter.call_args
+    assert kwargs["headers"] == (("x-scope-orgid", "pw-tartan"),)
+    assert set_provider.called
+
+
+def test_init_tracing_org_id_override(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "pw-tartan")     # would resolve to pw-tartan...
+    _, exporter, _ = _install_and_capture(org_id="admins")  # ...but override wins
+    _, kwargs = exporter.call_args
+    assert kwargs["headers"] == (("x-scope-orgid", "admins"),)
+
+
+def test_init_tracing_is_idempotent(monkeypatch):
+    monkeypatch.setenv("PLAID_TRACING_ENABLED", "true")
+    monkeypatch.setenv("POD_NAMESPACE", "pw-tartan")
+    assert _install_and_capture()[0] is True
+    # second call: already initialized → returns True but does not rebuild the exporter
+    result, exporter, set_provider = _install_and_capture()
+    assert result is True
+    assert not exporter.called
+    assert not set_provider.called
 
 
 def test_inject_is_noop_without_active_span():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ full = [
     "python-dateutil>=1.5.0",
     "python-magic>=0.4.12",
 ]
+# Services that call init_tracing() install this extra; the OTLP/gRPC exporter pulls in
+# grpcio, kept out of the base dependency every plaidcloud.rpc consumer gets.
+tracing = [
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-grpc",
+]
 
 [project.urls]
 Homepage = "https://plaidcloud.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ test = [
     "sqlalchemy-greenplum",
     "sqlalchemy-hana",
     "starrocks",
-    "snowflake-sqlalchemy"
+    "snowflake-sqlalchemy",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-grpc"
 ]
 full = [
     "chardet>=2.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bleach
 comtypes;platform_system=="Windows"
+opentelemetry-api
 packaging
 PyJWT
 PyYAML


### PR DESCRIPTION
## What
WI-1 of the Tempo tracing epic ([22869](https://app.shortcut.com/plaidcloud/epic/22869)) — the shared bootstrap that unblocks all other services.

- New `plaidcloud/rpc/telemetry.py`:
  - `init_tracing(service_name, org_id=None)` — installs a `TracerProvider` exporting to Tempo over OTLP gRPC (`tempo-distributor.cluster-components.svc:4317`), `ParentBased(TraceIdRatioBased)` sampler, `BatchSpanProcessor`, static `x-scope-orgid` gRPC metadata. No-op unless `PLAID_TRACING_ENABLED=true`.
  - `telemetry_org_id()` — resolves the multitenancy org-id from the **pod's own namespace** (`pw-<tenant>`/`ps-<tenant>`, else `admins`), read from the downward-API file with `POD_NAMESPACE` env fallback. This is the value the tenant's Grafana datasource reads and Promtail tags logs with — verified live on `pw-bug-fixes`. Deliberately does **not** use `keycloak.is_tenant_realm()` (absent from currently-deployed images) or bare `cfg.tenant.id` (which would write to the wrong org and silently drop traces).
  - `inject_trace_context()` / `shutdown_tracing()`.
- `http_json_rpc` injects W3C trace context into outbound headers (before any `FuturesSession`/thread handoff).

## Dependencies
- `opentelemetry-api` → base requirement (used by the always-called inject).
- SDK + OTLP/gRPC exporter → `tracing` extra, so grpcio isn't forced on every `plaidcloud.rpc` consumer.

## Safety
Fully inert behind `PLAID_TRACING_ENABLED` (default off); `inject_trace_context` with no active span writes nothing.

## Verified
Exercised in a venv: org-id passthrough + `admins` fallback, inert-when-disabled, no-op inject with no span, real `traceparent` injection under an active span, provider flush. Both files `py_compile` clean.

sc-22870