### PR TITLE
Enable tracing by default, gated on collector reachability

### DIFF
--- a/plaidcloud/rpc/telemetry.py
+++ b/plaidcloud/rpc/telemetry.py
@@ -3,16 +3,24 @@
 
 Single-tenant per process: each RPC pod serves one tenant, so a static
 ``X-Scope-OrgID`` (the pod's own ``pw-<tenant>``/``ps-<tenant>`` namespace) is set
-once at startup and rides every span export. Inert unless ``PLAID_TRACING_ENABLED``
-is true — importing this module has no effect until ``init_tracing`` is called.
+once at startup and rides every span export.
+
+Tracing is **on by default** — no env var required. It self-enables only where the
+OTLP collector is actually resolvable, so it lights up in clusters that run Tempo and
+stays cleanly off (no failing exporter) where Tempo isn't deployed. Set
+``PLAID_TRACING_ENABLED=false`` to force it off regardless. Importing this module has
+no effect until ``init_tracing`` is called.
 """
 
 import os
+import socket
 
 _DOWNWARD_API_NAMESPACE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 _DEFAULT_SAMPLE_RATIO = 0.05
+_DEFAULT_ENDPOINT = "tempo-distributor.cluster-components.svc:4317"
 
 _initialized = False
+_tracing_on = None  # cached tracing_enabled() result (flag ∧ collector reachable)
 
 
 def _pod_namespace():
@@ -38,8 +46,30 @@ def telemetry_org_id():
     return ns if ns.startswith(("pw-", "ps-")) else "admins"
 
 
+def _endpoint():
+    return os.environ.get("PLAID_TRACING_OTLP_ENDPOINT", _DEFAULT_ENDPOINT)
+
+
+def _collector_reachable(endpoint):
+    """Whether the OTLP collector host resolves. Keeps default-on tracing from installing
+    a doomed exporter (and spamming export errors) in clusters where Tempo isn't deployed."""
+    host = endpoint.split("://", 1)[-1].rsplit(":", 1)[0]
+    try:
+        socket.getaddrinfo(host, None)
+        return True
+    except OSError:
+        return False
+
+
 def tracing_enabled():
-    return os.environ.get("PLAID_TRACING_ENABLED", "false").lower() == "true"
+    """Whether tracing should run: on by default (``PLAID_TRACING_ENABLED`` defaults true;
+    set it to ``false`` to force off) **and** the OTLP collector is resolvable. The
+    reachability probe runs once and is cached, so this is cheap on the hot path."""
+    global _tracing_on
+    if _tracing_on is None:
+        flag = os.environ.get("PLAID_TRACING_ENABLED", "true").lower() == "true"
+        _tracing_on = flag and _collector_reachable(_endpoint())
+    return _tracing_on
 
 
 def _sample_ratio():
@@ -79,9 +109,7 @@ def init_tracing(service_name, org_id=None):
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
     org = org_id or telemetry_org_id()
-    endpoint = os.environ.get(
-        "PLAID_TRACING_OTLP_ENDPOINT", "tempo-distributor.cluster-components.svc:4317"
-    )
+    endpoint = _endpoint()
     ratio = _sample_ratio()
 
     provider = TracerProvider(

--- a/plaidcloud/rpc/telemetry.py
+++ b/plaidcloud/rpc/telemetry.py
@@ -64,7 +64,13 @@ def _collector_reachable(endpoint):
 def tracing_enabled():
     """Whether tracing should run: on by default (``PLAID_TRACING_ENABLED`` defaults true;
     set it to ``false`` to force off) **and** the OTLP collector is resolvable. The
-    reachability probe runs once and is cached, so this is cheap on the hot path."""
+    reachability probe runs once and is cached, so this is cheap on the hot path.
+
+    The result — including a negative — is cached for the process lifetime; a transient
+    DNS failure at startup would latch tracing off until a restart. That is an accepted
+    tradeoff: init_tracing (the first caller) runs at startup after DB/redis init, by
+    which point cluster DNS is up, and pods restart routinely. Caching is required because
+    the alternative — re-probing DNS on every hot-path call — is not viable."""
     global _tracing_on
     if _tracing_on is None:
         flag = os.environ.get("PLAID_TRACING_ENABLED", "true").lower() == "true"

--- a/plaidcloud/rpc/tests/test_telemetry.py
+++ b/plaidcloud/rpc/tests/test_telemetry.py
@@ -49,11 +49,18 @@ def test_org_id_non_tenant_is_admins(monkeypatch):
     assert telemetry.telemetry_org_id() == "admins"
 
 
-def test_collector_reachable(monkeypatch):
-    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [("x",)])
-    assert telemetry._collector_reachable("tempo-distributor.cluster-components.svc:4317") is True
-    monkeypatch.setattr("socket.getaddrinfo", mock.Mock(side_effect=OSError))
-    assert telemetry._collector_reachable("nope:4317") is False
+def test_collector_reachable_parses_host_and_resolves():
+    gai = mock.Mock(return_value=[("x",)])
+    with mock.patch("socket.getaddrinfo", gai):
+        assert telemetry._collector_reachable("tempo-distributor.cluster-components.svc:4317") is True
+        assert gai.call_args[0][0] == "tempo-distributor.cluster-components.svc"   # port stripped
+        assert telemetry._collector_reachable("http://tempo-distributor.cluster-components.svc:4318") is True
+        assert gai.call_args[0][0] == "tempo-distributor.cluster-components.svc"   # scheme + port stripped
+
+
+def test_collector_unreachable_on_resolve_failure():
+    with mock.patch("socket.getaddrinfo", mock.Mock(side_effect=OSError)):
+        assert telemetry._collector_reachable("nope:4317") is False
 
 
 def test_tracing_on_by_default_when_collector_reachable(monkeypatch):

--- a/plaidcloud/rpc/tests/test_telemetry.py
+++ b/plaidcloud/rpc/tests/test_telemetry.py
@@ -12,11 +12,14 @@ from plaidcloud.rpc import telemetry
 
 
 @pytest.fixture(autouse=True)
-def _reset_initialized():
-    """init_tracing is idempotent via a module-level flag; reset it between tests."""
+def _reset_module_state():
+    """init_tracing is idempotent and tracing_enabled() caches its probe via module-level
+    globals; reset both between tests."""
     telemetry._initialized = False
+    telemetry._tracing_on = None
     yield
     telemetry._initialized = False
+    telemetry._tracing_on = None
 
 
 def test_pod_namespace_reads_downward_api_file():
@@ -46,11 +49,36 @@ def test_org_id_non_tenant_is_admins(monkeypatch):
     assert telemetry.telemetry_org_id() == "admins"
 
 
-def test_tracing_enabled_flag(monkeypatch):
-    monkeypatch.setenv("PLAID_TRACING_ENABLED", "TRUE")
+def test_collector_reachable(monkeypatch):
+    monkeypatch.setattr("socket.getaddrinfo", lambda *a, **k: [("x",)])
+    assert telemetry._collector_reachable("tempo-distributor.cluster-components.svc:4317") is True
+    monkeypatch.setattr("socket.getaddrinfo", mock.Mock(side_effect=OSError))
+    assert telemetry._collector_reachable("nope:4317") is False
+
+
+def test_tracing_on_by_default_when_collector_reachable(monkeypatch):
+    monkeypatch.delenv("PLAID_TRACING_ENABLED", raising=False)   # no env var → default on
+    monkeypatch.setattr(telemetry, "_collector_reachable", lambda ep: True)
     assert telemetry.tracing_enabled() is True
+
+
+def test_tracing_off_when_flag_false(monkeypatch):
     monkeypatch.setenv("PLAID_TRACING_ENABLED", "false")
+    monkeypatch.setattr(telemetry, "_collector_reachable", lambda ep: True)
     assert telemetry.tracing_enabled() is False
+
+
+def test_tracing_off_when_collector_unreachable(monkeypatch):
+    monkeypatch.delenv("PLAID_TRACING_ENABLED", raising=False)   # default on...
+    monkeypatch.setattr(telemetry, "_collector_reachable", lambda ep: False)
+    assert telemetry.tracing_enabled() is False                 # ...but no collector → off
+
+
+def test_tracing_enabled_probe_is_cached(monkeypatch):
+    monkeypatch.setattr(telemetry, "_collector_reachable", lambda ep: True)
+    assert telemetry.tracing_enabled() is True
+    monkeypatch.setattr(telemetry, "_collector_reachable", lambda ep: False)  # flip
+    assert telemetry.tracing_enabled() is True                 # cached, not re-probed
 
 
 def test_init_tracing_noop_when_disabled(monkeypatch):
@@ -72,7 +100,7 @@ def test_sample_ratio_default_clamp_and_malformed(monkeypatch):
 
 
 def _install_and_capture(service="plaid-rpc-test", org_id=None):
-    with mock.patch(
+    with mock.patch.object(telemetry, "_collector_reachable", return_value=True), mock.patch(
         "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
     ) as exporter, mock.patch(
         "opentelemetry.sdk.trace.export.BatchSpanProcessor"


### PR DESCRIPTION
## What
Makes tracing **on by default** — no `PLAID_TRACING_ENABLED=true` required — while staying safe in clusters without Tempo.

`tracing_enabled()` now returns `(flag-on ∧ collector-reachable)`:
- `PLAID_TRACING_ENABLED` defaults to `true` (set `false` to force off).
- The OTLP collector host is DNS-probed **once** and cached; if it doesn't resolve, tracing self-disables.

## Why the reachability gate
Verified live: **Tempo runs only in ci-cluster** — it's absent in both prod clusters (tenants-red, prod-blue). A naive default-on would make every prod pod's exporter fail against a non-existent `tempo-distributor` DNS name, spamming errors across 19 tenants. The gate lights tracing up where Tempo exists and keeps it cleanly off (no provider installed) where it doesn't. DNS discrimination confirmed in-cluster (real service → resolves, absent service → doesn't).

## Scope
Contained to `telemetry.py`. All existing hot-path gates already call `tracing_enabled()` (or `_initialized` for the client inject), so no consumer code changes — only a version bump to pick this up. Probe is cached, so no per-request DNS cost.

## Tests
100% coverage retained: default-on-when-reachable, off-when-flag-false, off-when-unreachable, probe-is-cached, and `_collector_reachable` both branches.