### PR TITLE
Add currency analyze dtype (PlaidCurrency, explicit DECIMAL(18, 4))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add a `currency` analyze data type: the new `PlaidCurrency` SQLAlchemy type renders an explicit `DECIMAL(18, 4)` on every warehouse dialect (8-byte Decimal64 values on Databend), with matching pandas (`float64`) and arrow (`decimal128(18, 4)`) conversions. Type inference is unchanged — `currency` source-type spellings still map to `numeric`; only an explicitly stored `currency` dtype gets the narrow type ([@inviscid](https://github.com/inviscid)).

--- a/plaidcloud/rpc/database.py
+++ b/plaidcloud/rpc/database.py
@@ -203,6 +203,21 @@ class PlaidNumeric(TypeDecorator):
             return self.impl
 
 
+class PlaidCurrency(TypeDecorator):
+    """Money type that renders an explicit DECIMAL(18, 4) on every dialect.
+
+    Precision <= 18 keeps Databend values on 8-byte Decimal64 (and Parquet on
+    INT64); a bare NUMERIC falls back to Databend's DECIMAL(38, 10) default,
+    so the precision is always emitted explicitly.
+    """
+    impl = DECIMAL(18, 4)
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        asdecimal = not is_dialect_snowflake_based(dialect)  # Same snowflake quirk as PlaidNumeric
+        return dialect.type_descriptor(DECIMAL(18, 4, asdecimal=asdecimal))
+
+
 class PlaidUnicode(TypeDecorator):
     """Unicode Type that implements as UnicodeText on Postgresql based environments
 

--- a/plaidcloud/rpc/tests/test_database.py
+++ b/plaidcloud/rpc/tests/test_database.py
@@ -21,6 +21,7 @@ from plaidcloud.rpc.database import (
     StartPath,
     PlaidTimestamp,
     PlaidNumeric,
+    PlaidCurrency,
     PlaidUnicode,
     PlaidJSON,
     PlaidTinyInt,
@@ -268,6 +269,49 @@ class TestPlaidNumericDialect:
         pn = PlaidNumeric()
         impl = pn.load_dialect_impl(pg)
         assert impl is pn.impl or impl is not None
+
+
+class TestPlaidCurrencyDDL:
+    """The emitted DDL is load-bearing: a bare NUMERIC falls back to
+    DECIMAL(38, 10) on Databend, which doubles storage to Decimal128."""
+
+    def test_default_compile_is_explicit_18_4(self):
+        assert str(PlaidCurrency()) == 'DECIMAL(18, 4)'
+
+    @pytest.mark.parametrize('dialect_factory', [PGDialect, MSDialect, MySQLDialect])
+    def test_core_dialects_emit_18_4(self, dialect_factory):
+        compiled = PlaidCurrency().compile(dialect=dialect_factory())
+        assert compiled in ('DECIMAL(18, 4)', 'NUMERIC(18, 4)')
+
+    @pytest.mark.skipif(DatabendDialect is None, reason="databend_sqlalchemy not installed")
+    def test_databend_emits_decimal_18_4(self):
+        assert PlaidCurrency().compile(dialect=DatabendDialect()) == 'DECIMAL(18, 4)'
+
+    @pytest.mark.skipif(StarRocksDialect is None, reason="starrocks not installed")
+    def test_starrocks_emits_18_4(self):
+        compiled = PlaidCurrency().compile(dialect=StarRocksDialect())
+        assert '18, 4' in compiled and compiled.upper().startswith(('DECIMAL', 'NUMERIC'))
+
+    @pytest.mark.skipif(SnowflakeDialect is None, reason="snowflake-sqlalchemy not installed")
+    def test_snowflake_emits_18_4(self):
+        compiled = PlaidCurrency().compile(dialect=SnowflakeDialect())
+        assert '(18, 4)' in compiled
+
+    def test_never_bare_numeric(self):
+        # Every dialect branch must carry explicit precision
+        for dialect in (PGDialect(), MSDialect(), MySQLDialect()):
+            impl = PlaidCurrency().load_dialect_impl(dialect)
+            assert impl.precision == 18 and impl.scale == 4
+            assert impl.asdecimal is True
+
+    @pytest.mark.skipif(SnowflakeDialect is None, reason="snowflake-sqlalchemy not installed")
+    def test_snowflake_returns_floats(self):
+        # The one asdecimal=False dialect — mirrors PlaidNumeric's snowflake quirk
+        assert PlaidCurrency().load_dialect_impl(SnowflakeDialect()).asdecimal is False
+
+    @pytest.mark.skipif(DatabendDialect is None, reason="databend_sqlalchemy not installed")
+    def test_databend_asdecimal_true(self):
+        assert PlaidCurrency().load_dialect_impl(DatabendDialect()).asdecimal is True
 
 
 class TestPlaidUnicodeDialect:

--- a/plaidcloud/rpc/tests/test_type_conversion.py
+++ b/plaidcloud/rpc/tests/test_type_conversion.py
@@ -21,7 +21,7 @@ from plaidcloud.rpc.type_conversion import (
 )
 from plaidcloud.rpc.messytables.core import Cell
 from plaidcloud.rpc.database import (
-    PlaidUnicode, PlaidNumeric, PlaidTimestamp, PlaidJSON, GUIDHyphens, PlaidTinyInt,
+    PlaidNumeric, PlaidCurrency, PlaidTimestamp, PlaidJSON, GUIDHyphens,
 )
 
 
@@ -116,6 +116,7 @@ class TestPandasDtypeFromSql:
         ('integer', 'Int64'),
         ('bigint', 'Int64'),
         ('numeric', 'float64'),
+        ('currency', 'float64'),
         ('timestamp', 'datetime64[s]'),
         ('interval', 'timedelta64[s]'),
         ('date', 'datetime64[s]'),
@@ -172,6 +173,16 @@ class TestSqlalchemyFromDtype:
 
     def test_largebinary(self):
         assert sqlalchemy_from_dtype('largebinary') is LargeBinary
+
+    def test_currency(self):
+        assert sqlalchemy_from_dtype('currency') is PlaidCurrency
+
+    def test_currency_source_spelling_still_infers_numeric(self):
+        # The user-selected dtype and the source-type spelling are distinct:
+        # inference keeps collapsing 'currency' source names to numeric, so
+        # only an explicitly stored 'currency' dtype reaches PlaidCurrency.
+        assert analyze_type('currency') == 'numeric'
+        assert sqlalchemy_from_dtype(analyze_type('currency')) is PlaidNumeric
 
 
 class TestPostgresToPythonDateFormat:
@@ -293,6 +304,18 @@ class TestArrowTypeFromAnalyzeType:
     def test_integer_type(self):
         result = arrow_type_from_analyze_type('integer')
         assert result is not None
+
+    @_REQUIRES_JSON
+    def test_currency_is_decimal128_18_4(self):
+        import pyarrow
+        assert arrow_type_from_analyze_type('currency') == pyarrow.decimal128(18, 4)
+
+    @_REQUIRES_JSON
+    def test_currency_ignores_use_decimal_type(self):
+        # use_decimal_type is only set by SF/MSSQL callers; currency must not
+        # widen to decimal128(38, 10) there.
+        import pyarrow
+        assert arrow_type_from_analyze_type('currency', use_decimal_type=True) == pyarrow.decimal128(18, 4)
 
     def test_import_error_raises(self):
         # Simulate pyarrow not being installed

--- a/plaidcloud/rpc/type_conversion.py
+++ b/plaidcloud/rpc/type_conversion.py
@@ -10,7 +10,7 @@ if sqlalchemy.__version__.startswith('2.'):
 else:  # pragma: no cover
     from databend_sqlalchemy.types import DOUBLE
 from plaidcloud.rpc.database import (
-    PlaidUnicode, PlaidNumeric, PlaidTimestamp, PlaidJSON, GUIDHyphens, PlaidTinyInt, PlaidGeography, PlaidGeometry
+    PlaidUnicode, PlaidNumeric, PlaidCurrency, PlaidTimestamp, PlaidJSON, GUIDHyphens, PlaidTinyInt, PlaidGeography, PlaidGeometry
 )
 
 
@@ -109,6 +109,7 @@ _PANDAS_DTYPE_FROM_SQL = regex_map({
     r'^integer$': 'Int64',
     r'^bigint$': 'Int64',
     r'^numeric$': 'float64',
+    r'^currency$': 'float64',
     r'^decimal.*': 'float64',
     r'^timestamp\b.*': 'datetime64[s]',
     r'^interval$': 'timedelta64[s]',
@@ -141,6 +142,10 @@ def arrow_type_from_analyze_type(dtype: str, use_decimal_type: bool = False):
     if dtype.startswith('json'):
         # Numpy treats this like a generic object, specify json
         return json_()
+    if dtype == 'currency':
+        # Stored user-declared money type — always an exact decimal in parquet,
+        # regardless of use_decimal_type (which callers only set for SF/MSSQL).
+        return decimal128(18, 4)
     np_type = pandas_dtype_from_sql(dtype)
     if np_type == 'object':
         # Fall back to string
@@ -280,6 +285,12 @@ def analyze_type(dtype):
     Returns:
         (str): An analyze dtype. Should be one of ('text', 'numeric', 'smallint',
         'integer', 'bigint', 'boolean', 'date', 'time', 'timestamp', 'interval')
+
+    Note:
+        'currency' is a stored, user-selected analyze dtype that this function
+        never returns — the 'currency' *input* spelling here is a source type
+        name (e.g. MS Access Currency, a 19,4 decimal) and maps to 'numeric'
+        so inference can never auto-narrow money into DECIMAL(18, 4).
     Examples:
         >>> analyze_type('time')
         'time'
@@ -373,6 +384,7 @@ _sqlalchemy_from_dtype = regex_map({
     r'^bigint$': BIGINT,
     r'^float\d*': FLOAT,
     r'^numeric.*': PlaidNumeric,
+    r'^currency$': PlaidCurrency,
     r'^decimal.*': PlaidNumeric,
     r'^datetime.*': PlaidTimestamp,  # This may have to cover all datetimes
     r'^timestamp\b.*': PlaidTimestamp,


### PR DESCRIPTION
## What

New `currency` analyze dtype for money columns. `PlaidCurrency` renders an explicit `DECIMAL(18, 4)` on every dialect (8-byte Decimal64 on Databend — half the width of numeric's `DECIMAL(38, 10)`), with pandas (`float64`) and arrow (`decimal128(18, 4)`) conversions.

Inference is deliberately unchanged: `analyze_type('currency')` still returns `numeric` (a source-type spelling like MS Access Currency is a 19,4 decimal that must never auto-narrow); only an explicitly stored `currency` dtype reaches `PlaidCurrency`.

## Why

usesi's Superset money dashboards are I/O-bound on wide `Decimal(38,10)` scans (73–290s → timeouts). Currency columns halve the scanned width. Empirically verified on the exact prod engine (Databend v1.2.790: 8.13 vs 16.13 bytes/row; StarRocks/Iceberg parquet: −33%).

## Release sequencing

**Release this first** (as 1.9.0), then plaid-utilities 1.10.0, then workflow-runner/plaid/client PRs (their pins reference these versions).

## Testing

209 passed (all-dialect emitted-DDL tests incl. databend/starrocks/snowflake; `str(PlaidCurrency()) == 'DECIMAL(18, 4)'` pinned; asdecimal semantics pinned). Sonnet adversarial review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)