### PR TITLE
feat(config): configure a connection from explicit arguments (sc-21805)

### DIFF
--- a/plaidcloud/rpc/config.py
+++ b/plaidcloud/rpc/config.py
@@ -196,6 +196,7 @@ class PlaidConfig:
     # Members for local and remote
     rpc_uri = ''
     auth_token = ''
+    token_provider = None
     _project_id = ''
     _workflow_id = ''
     _step_id = ''
@@ -219,7 +220,8 @@ class PlaidConfig:
     cache_locally = False
     write_from_local = False
 
-    def __init__(self, config_path: [str, False], working_user=''):
+    def __init__(self, config_path: [str, False], working_user='', *, rpc_uri='', auth_token='',
+                 token_provider=None, workspace_uuid='', project_id=''):
         """
         Configuration for running UDFs within Plaid
 
@@ -227,10 +229,37 @@ class PlaidConfig:
         that can be deployed on a Windows server and then be reliably called.  Enables common usage of shared
         files, regardless of who the local user happens to be.  This was essential for deploying KC reporting.
 
+        Configuration comes from one of three sources: the arguments here, environment
+        variables, or a plaid.conf on disk, in that order of preference. Passing rpc_uri
+        selects the arguments and skips the other two entirely, which is the only option in
+        an environment that has neither env vars nor a readable filesystem. token_provider is
+        the exception: it says how to obtain a token rather than what the configuration is, so
+        it applies whichever source supplied the rest.
+
         Args:
             config_path (str):  client repo's config directory.  It's where to look for client-specific config yaml.
             working_user (str, optional): local user or overridden (typically 'plaidlink') user. defaults to os.path.expanduser('~')
+            rpc_uri (str, optional): full RPC endpoint, e.g. 'https://tenant.plaid.cloud/json-rpc/'. Selects direct configuration.
+            auth_token (str, optional): a bearer token. Required with rpc_uri unless token_provider is given.
+            token_provider (callable, optional): returns a bearer token, called per request. Use where the
+                token varies over the life of the connection (per-viewer sessions, refresh ahead of expiry).
+                Takes precedence over auth_token, from any configuration source.
+            workspace_uuid (str, optional): workspace/tenant id. Requires rpc_uri.
+            project_id (str, optional): project id. Requires rpc_uri. Callers that never name a project
+                may omit it; the project_id property still raises if something later needs one.
+
+        Raises:
+            ValueError: if rpc_uri is given without a token or provider, or if workspace_uuid or
+                project_id is given without rpc_uri (they would otherwise be silently ignored).
         """
+        # _C is declared at class level, so every instance shared one dict and config built
+        # in one place leaked into every other instance in the process. Rebind per instance
+        # before anything can write to it, including the PlaidXLConfig path that returns early.
+        self._C = {}
+        # Set regardless of which source configures the rest: a caller may take its context
+        # from the environment and still need to supply the token itself, per request.
+        self.token_provider = token_provider
+
         def _check_environment_variables():
             try:
                 # If this is running in UDF or Jupyter notebook then an RPC connection is already available
@@ -257,11 +286,23 @@ class PlaidConfig:
                 logger.debug("Environment not configured, running UDF Locally. Checking local configuration.")
                 return False
 
+        def _init_direct_params():
+            if not (auth_token or token_provider):
+                raise ValueError('rpc_uri requires either auth_token or token_provider.')
+            self.rpc_uri = rpc_uri
+            self.auth_token = auth_token
+            self.workspace_uuid = workspace_uuid
+            self._project_id = project_id
+            self.hostname = urlparse(rpc_uri).netloc or 'Unknown'
+
         def _init_plaidcloud_config():
             self.is_local = False
             self.debug = False
             self._C['LOCAL_STORAGE'] = None
-            self._C['project_id'] = self.project_id
+            # _project_id, not the project_id property: the property raises when unset, and a
+            # caller that never names a project is legitimate. It still raises at the point
+            # something actually needs a project.
+            self._C['project_id'] = self._project_id
             self._C['return_df'] = True
             self.fetch = True
             self.cache_locally = False
@@ -392,7 +433,13 @@ class PlaidConfig:
         if config_path is False: # allow to call super from PlaidXLConfig without effect
             return
 
-        if _check_environment_variables():
+        if not rpc_uri and (workspace_uuid or project_id):
+            raise ValueError('workspace_uuid and project_id require rpc_uri.')
+
+        if rpc_uri:
+            _init_direct_params()
+            _init_plaidcloud_config()
+        elif _check_environment_variables():
             _init_plaidcloud_config()
         else:
             _init_local_config()

--- a/plaidcloud/rpc/rpc_connect.py
+++ b/plaidcloud/rpc/rpc_connect.py
@@ -32,7 +32,9 @@ class Connect(PlaidConfig, SimpleRPC):
         [{'SELECT 1': 1}]
     """
 
-    def __init__(self, config_path=None, callable_listener=listener, auto_initialize=True, check_allow_transmit=lambda: True):
+    def __init__(self, config_path=None, callable_listener=listener, auto_initialize=True,
+                 check_allow_transmit=lambda: True, *, rpc_uri='', auth_token='',
+                 token_provider=None, workspace_uuid='', project_id=''):
         """Sets up initial data
 
         Args:
@@ -44,6 +46,9 @@ class Connect(PlaidConfig, SimpleRPC):
                 it must be called manually
             allow_transmit (func): Function to be called before making RPC calls to see if the call should actually
                 be made. It must take no args and return a boolean value.
+            rpc_uri, auth_token, token_provider, workspace_uuid, project_id: see PlaidConfig.
+                Passing rpc_uri configures the connection from these values alone, with no
+                environment variables and no plaid.conf.
         """
 
         self.callable_listener = callable_listener
@@ -52,7 +57,10 @@ class Connect(PlaidConfig, SimpleRPC):
         # it will find (and try to call) a `Namespace` object and fail. Not sure when this behavior was introduced, but
         # ensuring that we pass a function (not None) corrects this behavior.
         self.allow_transmit_func = check_allow_transmit
-        PlaidConfig.__init__(self, config_path=config_path)
+        PlaidConfig.__init__(
+            self, config_path=config_path, rpc_uri=rpc_uri, auth_token=auth_token,
+            token_provider=token_provider, workspace_uuid=workspace_uuid, project_id=project_id,
+        )
         if not self.is_local:
             self.ready()
         elif self.is_local and auto_initialize:
@@ -147,7 +155,10 @@ class Connect(PlaidConfig, SimpleRPC):
 
     def ready(self):
         """Call SimpleRPC __init__ once we have an auth token"""
-        SimpleRPC.__init__(self, self.auth_token, uri=self.rpc_uri, check_allow_transmit=self.allow_transmit_func)
+        # SimpleRPC resolves a callable per request, so a token_provider gives each request a
+        # fresh token rather than one captured at connection time.
+        SimpleRPC.__init__(self, self.token_provider or self.auth_token, uri=self.rpc_uri,
+                           check_allow_transmit=self.allow_transmit_func)
 
 
 class PlaidXLConnect(SimpleRPC, PlaidXLConfig):

--- a/plaidcloud/rpc/tests/test_config.py
+++ b/plaidcloud/rpc/tests/test_config.py
@@ -179,6 +179,112 @@ class TestFindWorkspaceRoot:
         assert str(result) == str(d)
 
 
+class TestPlaidConfigDirectParams:
+    """Tests configuring PlaidConfig from explicit arguments, with neither environment
+    variables nor a plaid.conf available."""
+
+    def test_configures_without_env_or_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv('__PLAID_RPC_URI__', raising=False)
+        monkeypatch.delenv('__PLAID_RPC_AUTH_TOKEN__', raising=False)
+        monkeypatch.chdir(tmp_path)  # nothing to find if it were to look
+        cfg = PlaidConfig(
+            config_path=None, rpc_uri='https://t.plaid.cloud/json-rpc/', auth_token='tok',
+            workspace_uuid='ws', project_id='pid',
+        )
+        assert cfg.rpc_uri == 'https://t.plaid.cloud/json-rpc/'
+        assert cfg.auth_token == 'tok'
+        assert cfg.workspace_uuid == 'ws'
+        assert cfg.project_id == 'pid'
+        assert cfg.hostname == 't.plaid.cloud'
+        assert cfg.is_local is False
+
+    def test_explicit_args_win_over_environment(self, monkeypatch):
+        monkeypatch.setenv('__PLAID_RPC_URI__', 'https://from-env.example.com/json-rpc/')
+        monkeypatch.setenv('__PLAID_RPC_AUTH_TOKEN__', 'env-tok')
+        monkeypatch.setenv('__PLAID_PROJECT_ID__', 'env-pid')
+        monkeypatch.setenv('__PLAID_WORKSPACE_UUID__', 'env-ws')
+        monkeypatch.setenv('__PLAID_WORKFLOW_ID__', 'env-wf')
+        monkeypatch.setenv('__PLAID_STEP_ID__', 'env-step')
+        cfg = PlaidConfig(config_path=None, rpc_uri='https://direct.example.com/json-rpc/',
+                          auth_token='direct-tok')
+        assert cfg.rpc_uri == 'https://direct.example.com/json-rpc/'
+        assert cfg.auth_token == 'direct-tok'
+
+    def test_token_provider_accepted_without_auth_token(self):
+        cfg = PlaidConfig(config_path=None, rpc_uri='https://t.plaid.cloud/json-rpc/',
+                          token_provider=lambda: 'fresh')
+        assert cfg.token_provider() == 'fresh'
+        assert cfg.auth_token == ''
+
+    def test_requires_a_token_or_provider(self):
+        with pytest.raises(ValueError, match='auth_token or token_provider'):
+            PlaidConfig(config_path=None, rpc_uri='https://t.plaid.cloud/json-rpc/')
+
+    def test_project_id_may_be_omitted(self):
+        cfg = PlaidConfig(config_path=None, rpc_uri='https://t.plaid.cloud/json-rpc/',
+                          auth_token='tok')
+        assert cfg.all['project_id'] == ''
+        with pytest.raises(Exception, match='Project Id has not been set'):
+            cfg.project_id
+
+    def test_unparseable_rpc_uri_falls_back_to_unknown(self):
+        cfg = PlaidConfig(config_path=None, rpc_uri='not-a-url', auth_token='tok')
+        assert cfg.hostname == 'Unknown'
+
+    def test_ids_without_rpc_uri_raise_rather_than_being_ignored(self, monkeypatch):
+        """Without rpc_uri another source configures the connection, and these would be
+        dropped on the floor."""
+        monkeypatch.setenv('__PLAID_RPC_URI__', 'https://t.plaid.cloud/json-rpc/')
+        monkeypatch.setenv('__PLAID_RPC_AUTH_TOKEN__', 'tok')
+        monkeypatch.setenv('__PLAID_PROJECT_ID__', 'env-pid')
+        monkeypatch.setenv('__PLAID_WORKSPACE_UUID__', 'env-ws')
+        monkeypatch.setenv('__PLAID_WORKFLOW_ID__', 'wf')
+        monkeypatch.setenv('__PLAID_STEP_ID__', 'st')
+        with pytest.raises(ValueError, match='require rpc_uri'):
+            PlaidConfig(config_path=None, project_id='ignored-otherwise')
+        with pytest.raises(ValueError, match='require rpc_uri'):
+            PlaidConfig(config_path=None, workspace_uuid='ignored-otherwise')
+
+    def test_token_provider_applies_to_environment_config(self, monkeypatch):
+        """The server Panel case: context from the environment, token per viewer session."""
+        monkeypatch.setenv('__PLAID_RPC_URI__', 'https://t.plaid.cloud/json-rpc/')
+        monkeypatch.setenv('__PLAID_RPC_AUTH_TOKEN__', 'placeholder')
+        monkeypatch.setenv('__PLAID_PROJECT_ID__', 'pid')
+        monkeypatch.setenv('__PLAID_WORKSPACE_UUID__', 'ws')
+        monkeypatch.setenv('__PLAID_WORKFLOW_ID__', 'wf')
+        monkeypatch.setenv('__PLAID_STEP_ID__', 'st')
+
+        def provider():
+            return 'per-session'
+
+        cfg = PlaidConfig(config_path=None, token_provider=provider)
+        assert cfg.token_provider is provider
+        assert cfg.is_local is False
+
+
+class TestPlaidConfigInstanceIsolation:
+    """_C used to be a single class-level dict shared by every instance."""
+
+    def test_underscore_c_is_not_shared_between_instances(self):
+        first = PlaidConfig(config_path=None, rpc_uri='https://a.example.com/json-rpc/',
+                            auth_token='tok', project_id='a-project')
+        second = PlaidConfig(config_path=None, rpc_uri='https://b.example.com/json-rpc/',
+                             auth_token='tok', project_id='b-project')
+        first.all['leaked'] = True
+        assert 'leaked' not in second.all
+        assert second.all['project_id'] == 'b-project'
+
+    def test_plaidxl_config_also_gets_its_own_dict(self):
+        """PlaidXLConfig returns through the config_path is False branch, so the rebind
+        has to happen before it."""
+        first = PlaidXLConfig(rpc_uri='https://a.example.com/json-rpc/', auth_token='t',
+                              workspace_id='ws', project_id='p')
+        second = PlaidXLConfig(rpc_uri='https://b.example.com/json-rpc/', auth_token='t',
+                               workspace_id='ws', project_id='p')
+        first.all['leaked'] = True
+        assert 'leaked' not in second.all
+
+
 class TestPlaidConfigEnvironment:
     """Tests the environment variable path in PlaidConfig initialization."""
 

--- a/plaidcloud/rpc/tests/test_rpc_connect.py
+++ b/plaidcloud/rpc/tests/test_rpc_connect.py
@@ -25,6 +25,56 @@ class TestPlaidXLConnect:
         assert rpc.project_id == 'p1'
 
 
+class TestConnectDirectParams:
+    """Connect forwards direct configuration through to PlaidConfig, so a caller holding
+    the values needs neither environment variables nor a plaid.conf."""
+
+    @mock.patch('plaidcloud.rpc.rpc_connect.SimpleRPC.__init__')
+    def test_connects_without_env_or_file(self, mock_srpc_init, monkeypatch, tmp_path):
+        mock_srpc_init.return_value = None
+        monkeypatch.delenv('__PLAID_RPC_URI__', raising=False)
+        monkeypatch.delenv('__PLAID_RPC_AUTH_TOKEN__', raising=False)
+        monkeypatch.chdir(tmp_path)
+        connect = Connect(rpc_uri='https://t.plaid.cloud/json-rpc/', auth_token='tok',
+                          workspace_uuid='ws', project_id='pid')
+        assert connect.is_local is False
+        assert connect.project_id == 'pid'
+        mock_srpc_init.assert_called_once()
+        assert mock_srpc_init.call_args.args[1] == 'tok'
+
+    @mock.patch('plaidcloud.rpc.rpc_connect.SimpleRPC.__init__')
+    def test_ready_passes_the_provider_itself_not_its_result(self, mock_srpc_init):
+        """SimpleRPC resolves a callable per request; handing it the result once would
+        pin every request to the token that happened to be current at connect time."""
+        mock_srpc_init.return_value = None
+
+        def provider():
+            return 'fresh-token'
+
+        connect = Connect.__new__(Connect)
+        connect.auth_token = ''
+        connect.token_provider = provider
+        connect.rpc_uri = 'https://example.com'
+        connect.allow_transmit_func = lambda: True
+        connect.ready()
+        assert mock_srpc_init.call_args.args[1] is provider
+
+    @mock.patch('plaidcloud.rpc.rpc_connect.SimpleRPC.__init__')
+    def test_provider_wins_over_a_static_token(self, mock_srpc_init):
+        mock_srpc_init.return_value = None
+
+        def provider():
+            return 'fresh-token'
+
+        connect = Connect.__new__(Connect)
+        connect.auth_token = 'static'
+        connect.token_provider = provider
+        connect.rpc_uri = 'https://example.com'
+        connect.allow_transmit_func = lambda: True
+        connect.ready()
+        assert mock_srpc_init.call_args.args[1] is provider
+
+
 class TestConnect:
     """Connect inherits from PlaidConfig which reads env/files.
     Tests exercise only pieces that don't require a fully-wired environment."""


### PR DESCRIPTION
Ref: [sc-21805](https://app.shortcut.com/plaidcloud/story/21805)

## Problem

`PlaidConfig` can be built exactly two ways: from a complete set of six `__PLAID_*` environment variables, or from a `plaid.conf` on disk. A caller that already holds the values has no way in. Every such caller works around it:

| Caller | Workaround |
|---|---|
| Jupyter | passes `workflow_id_not_set` / `step_id_not_set` sentinels |
| Server Panel | injects 4 placeholder env vars, then monkeypatches `Connect.ready` **and** `PlaidConnection.__init__` |
| PlaidXL | a parallel class pair reached through a `config_path is False` escape hatch |
| WASM | a forked plaid-rpc plus a `plaid.conf` in a document account |

The env gate is all-or-nothing — `platform-panel-base`'s own comment says so: *"builds its (non-secret) context + a token from these env vars, all-or-nothing."*

## Change

Keyword arguments on `PlaidConfig` and `Connect`. Passing `rpc_uri` configures from the arguments alone and skips both fallbacks. **Existing callers pass no new arguments and take exactly the same path as before.**

`token_provider` is a separate field rather than allowing a callable in `auth_token`. `SimpleRPC` already resolves a callable per request, but `auth_token` is public and read by out-of-tree code (tenant UDFs, notebooks) that would format a callable straight into a header. It applies whichever source configured the rest — it says *how* to get a token, not *what* the config is — which is the server Panel case: context from the environment, token per viewer.

`workspace_uuid` / `project_id` raise without `rpc_uri` rather than being silently dropped.

### Two supporting fixes, both required by the new path

- **`_C` was a class attribute**, so every instance shared one dict and config built in one place leaked into every other instance in the process. Rebound per instance, before the `PlaidXLConfig` early return.
- **`_init_plaidcloud_config` read the `project_id` property**, which raises when unset — so a project-less connection could not be constructed at all. Reads `_project_id` now; the property still raises at the point something actually needs a project.

## Intentional behaviour changes

1. A config built after a remote one in the same process no longer inherits `LOCAL_STORAGE` / `project_id` / `return_df` from it. That leak is the bug above. The only readers are `frame_manager.download/load/load_new`, which take a caller-supplied dict, guard the reads, and could never have used the leaked `LOCAL_STORAGE` anyway — it leaks as `None`.
2. `__PLAID_PROJECT_ID__` set to an empty string no longer raises during construction.

## Deliberately not included

`verify_ssl`. `Connect.ready` never forwards it to `SimpleRPC`, so the argument would be silently ignored — an API that lies about TLS. Tracked separately; that same gap means **`verify=False` on every RPC call through `Connect` today**, which needs its own staged rollout.

## Verification

- 793 pass, 24 skipped (skips are optional DB drivers absent locally; CI installs `[test]`)
- `config.py` and `rpc_connect.py` at **100%** coverage
- `pylint -E` clean for changed files; `ruff` findings byte-identical to baseline
- Differential harness against a real `origin/master` checkout across five caller shapes (workflow-runner, Jupyter, panel-base, partial env, no env) plus PlaidXL — identical except the intended `_C` change above

## Sequencing

Merge, then **release to PyPI** before the `plaid-utilities` follow-up: that repo installs plaid-rpc from PyPI, so its kwarg-forwarding change is untestable until this ships. `PlaidConnection.__init__` currently calls `Connect.__init__(self)` and discards `*args, **kwargs` entirely, so this API is not reachable from `PlaidConnection` until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)