### PR TITLE
sc-23802: store StarRocks JSON columns as objects, not VARIANT strings

### DIFF
--- a/plaidcloud/rpc/database.py
+++ b/plaidcloud/rpc/database.py
@@ -20,7 +20,7 @@ import csv
 from operator import attrgetter
 
 from sqlalchemy.types import (TypeDecorator, DateTime, Unicode, CHAR, NVARCHAR, VARCHAR, UnicodeText, NUMERIC,
-                              TIMESTAMP, DATETIME, JSON, SMALLINT, VARBINARY, DECIMAL, String)
+                              TIMESTAMP, DATETIME, JSON, SMALLINT, VARBINARY, DECIMAL, String, UserDefinedType)
 
 
 import sqlalchemy
@@ -362,6 +362,41 @@ def _databricks_json_variant():  # pragma: no cover - requires databricks
     return JSONVariant
 
 
+@functools.lru_cache(maxsize=1)
+def _starrocks_json_variant():
+    """The installed starrocks dialect has no VARIANT type, and plain sqlalchemy.JSON suppresses
+    bind_expression on INSERT — so a bound dict is sent as a VARCHAR literal and StarRocks-on-Iceberg
+    stores the whole document as a VARIANT *string* (indexing returns NULL). Mirror the Snowflake/
+    Databricks variants: a plain type (not a JSON subclass, so bind_expression survives) that renders
+    JSON in DDL but wraps the bind in PARSE_JSON so the value stores as an object. Memoized for stable
+    class identity, same as the snowflake variant.
+    """
+    class JSONVariant(UserDefinedType):
+        cache_ok = True
+
+        def get_col_spec(self, **kw):
+            return 'JSON'
+
+        def bind_processor(self, dialect):
+            def process(value):
+                if value is None:
+                    return None
+                return json.dumps(value, ensure_ascii=False, separators=(',', ':'))
+            return process
+
+        def bind_expression(self, bindvalue):
+            return sqlalchemy.func.PARSE_JSON(bindvalue)
+
+        def result_processor(self, dialect, coltype):
+            def process(value):
+                if value is None:
+                    return None
+                return json.loads(value)
+            return process
+
+    return JSONVariant
+
+
 class PlaidJSON(TypeDecorator):
     """JSON type that implements as JSONB on Postgresql based environments
 
@@ -386,6 +421,8 @@ class PlaidJSON(TypeDecorator):
             return dialect.type_descriptor(_snowflake_json_variant())
         if is_dialect_databricks_based(dialect):  # pragma: no cover - requires databricks
             return dialect.type_descriptor(_databricks_json_variant())
+        if is_dialect_starrocks_based(dialect):
+            return dialect.type_descriptor(_starrocks_json_variant())
 
         return self.impl
 

--- a/plaidcloud/rpc/tests/test_database.py
+++ b/plaidcloud/rpc/tests/test_database.py
@@ -443,6 +443,41 @@ class TestPlaidJSONDialect:
         key2 = table.insert().values(j={'a': 1})._generate_cache_key()
         assert key1 == key2
 
+    @pytest.mark.skipif(StarRocksDialect is None, reason="starrocks not installed")
+    def test_starrocks_emits_json(self):
+        # DDL stays JSON so native internal-catalog schemas are untouched; Iceberg maps JSON->variant.
+        assert PlaidJSON().compile(dialect=StarRocksDialect()) == 'JSON'
+
+    @pytest.mark.skipif(StarRocksDialect is None, reason="starrocks not installed")
+    def test_starrocks_variant_json_round_trip(self):
+        # Bare sqlalchemy.JSON suppresses bind_expression on INSERT, so a bound dict lands as a
+        # VARIANT *string*. The custom type must wrap the bind in PARSE_JSON so it stores an object.
+        import sqlalchemy as sa
+        dialect = StarRocksDialect()
+        impl = PlaidJSON().load_dialect_impl(dialect)
+        bind = impl.bind_processor(dialect)
+        assert bind({'a': [1, 'b']}) == '{"a":[1,"b"]}'
+        assert bind(None) is None
+        result = impl.result_processor(dialect, None)
+        assert result('{"a": [1, "b"]}') == {'a': [1, 'b']}
+        assert result(None) is None
+        table = sa.Table('t', sa.MetaData(), sa.Column('j', PlaidJSON()))
+        compiled = str(table.insert().values(j={'a': 1}).compile(dialect=dialect))
+        assert 'parse_json' in compiled.lower()
+
+    @pytest.mark.skipif(StarRocksDialect is None, reason="starrocks not installed")
+    def test_starrocks_variant_class_identity_stable(self):
+        import sqlalchemy as sa
+        dialect = StarRocksDialect()
+        impl1 = PlaidJSON().load_dialect_impl(dialect)
+        impl2 = PlaidJSON().load_dialect_impl(dialect)
+        assert type(impl1) is type(impl2)
+        assert impl1._static_cache_key == impl2._static_cache_key
+        table = sa.Table('t', sa.MetaData(), sa.Column('j', PlaidJSON()))
+        key1 = table.insert().values(j={'a': 1})._generate_cache_key()
+        key2 = table.insert().values(j={'a': 1})._generate_cache_key()
+        assert key1 == key2
+
 
 class TestPlaidTinyIntDialect:
 


### PR DESCRIPTION
## Symptom
On a StarRocks Iceberg catalog, a `PlaidJSON` column stored a bound Python dict as a VARIANT **string** rather than an object — `j.a` reads back NULL and the whole document comes back as text.

## Root cause
`plaidcloud/rpc/database.py` — `PlaidJSON` (`impl = JSON`) had no StarRocks branch in `load_dialect_impl`, so it fell through to plain `sqlalchemy.JSON`. `sqlalchemy.JSON` **suppresses `bind_expression` on INSERT**, so the bound dict was sent as a VARCHAR literal:

```
INSERT INTO t (j) VALUES (%s)          -- before
INSERT INTO t (j) VALUES (PARSE_JSON(%s))  -- after
```

## Fix
Add a StarRocks branch returning a memoized plain `UserDefinedType` (NOT a `JSON` subclass, so `bind_expression` is forwarded) that:
- renders `JSON` in DDL (unchanged — native-catalog schemas untouched; Iceberg maps JSON→variant),
- wraps the bind in `PARSE_JSON` via `bind_expression`,
- serialises with `json.dumps(..., separators=(',',':'))` and parses reads with `json.loads`.

Mirrors the existing Snowflake/Databricks variant factories in the same file. The installed `starrocks` dialect (1.3.4) has no VARIANT type, so the type is self-contained rather than imported.

## Verification
`cd plaid-rpc && pip install -e '.[test]' && pytest plaidcloud/rpc/tests/ --cov=plaidcloud.rpc --cov-fail-under=100`
→ **854 passed, 100% coverage**. New `test_starrocks_variant_json_round_trip` asserts the compiled INSERT contains `parse_json(`; confirmed **fails-before** on unmodified master (bare JSON suppresses it), passes-after. Added DDL (`== 'JSON'`) and class-identity-stable tests mirroring the Snowflake cases.

## Scope
plaid-rpc only. The pin bumps in plaid/workflow-runner and the live StarRocks-Iceberg store-as-object confirmation are explicit human follow-ups.

Story: https://app.shortcut.com/plaidcloud/story/23802

🤖 Generated with [Claude Code](https://claude.com/claude-code)